### PR TITLE
fix: use RELEASE_TOKEN PAT for semantic-release pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # RELEASE_TOKEN is a fine-grained PAT (Contents: read/write) owned by the repo admin.
+      # semantic-release pushes the version-bump commit directly to master; the default
+      # GITHUB_TOKEN cannot bypass the branch ruleset on a personal repo, but the admin's
+      # PAT is covered by the ruleset's Repository-admin bypass.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ secrets.RELEASE_TOKEN }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -25,5 +30,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Semantic release (bumps version, changelog, tag, GitHub Release)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: pnpm exec semantic-release


### PR DESCRIPTION
The Release workflow failed on master: semantic-release could not push the version-bump commit because the default `GITHUB_TOKEN` is not covered by the branch ruleset (and personal repos cannot add the GitHub Actions app to the bypass list).

This switches the release job to a fine-grained PAT stored as the `RELEASE_TOKEN` secret (Contents: read/write, this repo only), owned by the repo admin and therefore covered by the existing Repository-admin bypass.

Requires the `RELEASE_TOKEN` secret to exist before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJf1LSQqLBz3ryDQwzBydC