### PR TITLE
chore(deps): ignore non-LTS Node major bumps on docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      # We deliberately track Node LTS only. Dependabot can't tell LTS from
+      # current, so major bumps are reviewed and applied manually once a new
+      # major goes Active LTS (see https://nodejs.org/en/about/previous-releases).
+      - dependency-name: 'node'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 # 1.0.0 (2026-07-17)
 
-
 ### Bug Fixes
 
-* remove pnpm cache from audit job and bump workflows to Node 22 ([73d2df2](https://github.com/yiddytlq/simple-countdown/commit/73d2df2593e44107b8d460a1a5f4861b071b3dd2))
-* restrict GITHUB_TOKEN to contents:read in CI workflows ([7743579](https://github.com/yiddytlq/simple-countdown/commit/7743579c0ab42f372e478ed4e15dce8730dc6780))
-* use RELEASE_TOKEN PAT for semantic-release pushes ([34ac53d](https://github.com/yiddytlq/simple-countdown/commit/34ac53d4f2406943c0e524a181c2e4ca3b801c80))
-
+- remove pnpm cache from audit job and bump workflows to Node 22 ([73d2df2](https://github.com/yiddytlq/simple-countdown/commit/73d2df2593e44107b8d460a1a5f4861b071b3dd2))
+- restrict GITHUB_TOKEN to contents:read in CI workflows ([7743579](https://github.com/yiddytlq/simple-countdown/commit/7743579c0ab42f372e478ed4e15dce8730dc6780))
+- use RELEASE_TOKEN PAT for semantic-release pushes ([34ac53d](https://github.com/yiddytlq/simple-countdown/commit/34ac53d4f2406943c0e524a181c2e4ca3b801c80))
 
 ### Features
 
-* modernize toolchain to pnpm, Vite, React 18, and strict TypeScript ([d7592c9](https://github.com/yiddytlq/simple-countdown/commit/d7592c9118a42bde2883152fe8279ff4e0cc2b52))
+- modernize toolchain to pnpm, Vite, React 18, and strict TypeScript ([d7592c9](https://github.com/yiddytlq/simple-countdown/commit/d7592c9118a42bde2883152fe8279ff4e0cc2b52))


### PR DESCRIPTION
## Summary
- Follow-up to closing #139 (node 24-alpine → 26-alpine). We deliberately track Node LTS only, and Dependabot has no concept of "LTS" — it just proposes every major bump.
- Adds an `ignore` rule to `.github/dependabot.yml` for `node` major version updates on the `docker` ecosystem, so Dependabot stops proposing non-LTS Node majors (e.g. 25, 26 until it goes LTS in October 2026) and this doesn't recur every week.

## Test plan
- [x] Validated YAML syntax and Prettier formatting of the updated `.github/dependabot.yml`
- [x] No source/build changes — CI (lint/format/typecheck/test/build/audit/secrets/CodeQL) should pass unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf9Na9wS3sjeGXnBHykmCR)_