### PR TITLE
fix: show configuration error instead of NaN countdown for invalid TIMER_TARGET

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 build/
+CHANGELOG.md
 coverage/
 pnpm-lock.yaml
 public/variables-final.js

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState, useMemo } from 'react';
 import { describe } from '../../service/date';
+import { resolveTarget } from '../../service/target';
 import Block from './Block';
 
-const end = window.target;
+const end = resolveTarget(window.target);
 
 function Home() {
   const [date, setDate] = useState(new Date());
@@ -18,6 +19,9 @@ function Home() {
   }, []);
 
   const described = useMemo(() => {
+    if (end === null) {
+      return null;
+    }
     return describe(date, end);
   }, [date]);
 
@@ -27,20 +31,33 @@ function Home() {
       style={{ backgroundImage: `url('${window.background}')` }}
     >
       <div className="flex flex-col items-center px-4">
-        {window.title && window.title.length > 0 && (
-          <div className="mb-4 text-center text-3xl text-white sm:mb-6 sm:text-4xl lg:text-5xl">
-            {window.title}
-          </div>
+        {described === null ? (
+          <>
+            <div className="mb-4 text-center text-3xl text-white sm:mb-6 sm:text-4xl lg:text-5xl">
+              No valid countdown target configured
+            </div>
+            <div className="text-center text-base text-white opacity-80">
+              Set TIMER_TARGET to an ISO 8601 date, e.g. 2026-12-31T23:59:59
+            </div>
+          </>
+        ) : (
+          <>
+            {window.title && window.title.length > 0 && (
+              <div className="mb-4 text-center text-3xl text-white sm:mb-6 sm:text-4xl lg:text-5xl">
+                {window.title}
+              </div>
+            )}
+            <div className="flex flex-wrap items-start justify-center gap-3 sm:gap-4">
+              {Object.entries(described).map(([key, value]) => (
+                <Block
+                  key={key}
+                  title={`${key}${value > 1 ? 's' : ''}`}
+                  value={value.toString().padStart(2, '0')}
+                />
+              ))}
+            </div>
+          </>
         )}
-        <div className="flex flex-wrap items-start justify-center gap-3 sm:gap-4">
-          {Object.entries(described).map(([key, value]) => (
-            <Block
-              key={key}
-              title={`${key}${value > 1 ? 's' : ''}`}
-              value={value.toString().padStart(2, '0')}
-            />
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/src/service/__tests__/Target.test.ts
+++ b/src/service/__tests__/Target.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTarget } from '../target';
+
+describe('resolveTarget', () => {
+  it('returns the date for a valid ISO string', () => {
+    const target = new Date('2030-01-01T00:00:00.000Z');
+    expect(resolveTarget(target)).toBe(target);
+  });
+
+  it('returns null for an empty string', () => {
+    expect(resolveTarget(new Date(''))).toBeNull();
+  });
+
+  it('returns null for a garbage string', () => {
+    expect(resolveTarget(new Date('not-a-date'))).toBeNull();
+  });
+
+  it("returns null for the raw '__END__' placeholder", () => {
+    expect(resolveTarget(new Date('__END__'))).toBeNull();
+  });
+});

--- a/src/service/target.ts
+++ b/src/service/target.ts
@@ -1,0 +1,6 @@
+// Validates the runtime-injected countdown target (window.target).
+// An unset/unparsable TIMER_TARGET — including the raw '__END__' placeholder when
+// variables.sh never ran — yields an Invalid Date, whose getTime() is NaN.
+export function resolveTarget(raw: Date): Date | null {
+  return Number.isNaN(raw.getTime()) ? null : raw;
+}


### PR DESCRIPTION
## Summary

Fixes roadmap item 1.1 of #148: an unset, empty, or unparsable `TIMER_TARGET` (including the raw `__END__` placeholder when `variables.sh` never ran) makes `window.target` an Invalid Date, so every countdown digit rendered `NaN`.

This is a client-side rendering fix only — `variables.sh`, `docker-entrypoint.sh`, and the runtime-injection pipeline are untouched.

Rebased onto master after the Tailwind CSS v4 migration (#150); the error panel now uses Tailwind utility classes.

## Changes

- **`src/service/target.ts`** (new): `resolveTarget(raw: Date): Date | null` — returns `null` when `raw.getTime()` is `NaN`. Verified that `new Date('__END__')`, `new Date('')`, and garbage strings all produce a `NaN` time, so the single check covers the unsubstituted-placeholder case too.
- **`src/scenes/Home/index.tsx`**: the module-scope `const end = window.target` is now resolved via `resolveTarget`. When it resolves to `null`, the app renders a configuration-error panel ("No valid countdown target configured" + a hint to set `TIMER_TARGET` to an ISO 8601 date) inside the existing full-screen background wrapper instead of the timer blocks, styled with the same Tailwind title utilities. Hooks remain unconditional; the valid-target rendering path is unchanged.
- **`src/service/__tests__/Target.test.ts`** (new): covers valid ISO string, empty string, garbage string, and the raw `__END__` placeholder.
- **`.prettierignore`**: exclude the semantic-release-generated `CHANGELOG.md` — the 1.1.0 release commit (`[skip ci]`) wrote `*` bullets that fail `pnpm format:check` on every subsequent PR; ignoring the generated file fixes it durably.

## Testing

All CI gates pass locally after the rebase: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (10 tests, 2 files), `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XZz39YjfQog2Vs7KEizc8