### PR TITLE
chore: ops hardening — pin action SHAs, Docker healthcheck, cache headers, startup logging

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -15,11 +15,11 @@ jobs:
   run-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.inputs.branch }}
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -33,21 +33,21 @@ jobs:
   secrets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Scan for committed secrets
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       # No cache here: audit reads the lockfile only, so there is no pnpm store to save
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Audit dependencies (fails on high/critical)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -17,11 +17,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.inputs.branch }}
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -32,7 +32,7 @@ jobs:
           TIMER_TARGET: ${{ secrets.TIMER_TARGET }}
           TIMER_TITLE: ${{ secrets.TIMER_TITLE }}
         run: pnpm build
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./build
 
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,20 +15,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Docker metadata (semver + latest tags)
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: yiddy/simple-countdown
           tags: |
@@ -36,7 +36,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@ jobs:
   file-labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
@@ -27,7 +27,7 @@ jobs:
   status-tracker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
       # semantic-release pushes the version-bump commit directly to master; the default
       # GITHUB_TOKEN cannot bypass the branch ruleset on a personal repo, but the admin's
       # PAT is covered by the ruleset's Repository-admin bypass.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ secrets.RELEASE_TOKEN }}
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Send Slack Notification
         if: ${{ steps.decision.outputs.should_notify == 'true' }}
-        uses: slackapi/slack-github-action@v4.0.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,7 @@ COPY variables.sh docker-entrypoint.sh /
 
 EXPOSE 3000
 
+# wget is a busybox applet already present in nginx:alpine-slim — no extra packages
+HEALTHCHECK CMD wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ services:
 
 Release images are tagged with their semantic version (e.g. `yiddy/simple-countdown:1.2.3`) as well as `latest`.
 
+### Logs
+
+Everything the container does is logged to stdout/stderr, so the standard Docker commands show it:
+
+```sh
+docker logs <container>       # or: docker compose logs -f web
+```
+
+What you'll see:
+
+- **Startup configuration summary** — the entrypoint confirms the runtime variables were injected
+  and reports, for each `TIMER_*` variable, whether it was set (values themselves are not logged).
+- **nginx access and error logs** — the image forwards them to stdout/stderr.
+- **Failures** — if variable injection fails, the reason is logged before the container exits.
+
+The image also ships a `HEALTHCHECK` that fetches `http://127.0.0.1:3000/`; inspect its status with:
+
+```sh
+docker inspect --format '{{json .State.Health}}' <container>
+```
+
 ## Without docker
 
 > This method builds the project with the env variables you provide, producing a `build` folder that has to be served manually afterwards.

--- a/__tests__/Variables.test.ts
+++ b/__tests__/Variables.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const script = join(root, 'variables.sh');
+const template = join(root, 'public', 'variables.js');
+
+let dir: string;
+
+function runVariables(env: Record<string, string>) {
+  return spawnSync('sh', [script, dir], {
+    env: { ...process.env, TIMER_BACKGROUND: '', TIMER_TARGET: '', TIMER_TITLE: '', ...env },
+    encoding: 'utf8',
+  });
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'variables-test-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// variables.sh needs a POSIX sh; the deployment targets (alpine, CI) are all Linux.
+describe.skipIf(process.platform === 'win32')('variables.sh', () => {
+  it('substitutes all TIMER_* placeholders and reports success', () => {
+    copyFileSync(template, join(dir, 'variables.js'));
+
+    const result = runVariables({
+      TIMER_BACKGROUND: 'https://example.com/bg.jpg',
+      TIMER_TARGET: '2026-12-31T23:59:59Z',
+      TIMER_TITLE: 'New year',
+    });
+
+    expect(result.status).toBe(0);
+    const final = readFileSync(join(dir, 'variables-final.js'), 'utf8');
+    expect(final).toContain('https://example.com/bg.jpg');
+    expect(final).toContain('2026-12-31T23:59:59Z');
+    expect(final).toContain('New year');
+    expect(final).not.toMatch(/__BACKGROUND__|__END__|__TITLE__/);
+    expect(result.stdout).toContain('substituted TIMER_* placeholders');
+  });
+
+  it('replaces placeholders with empty strings when the env vars are unset', () => {
+    copyFileSync(template, join(dir, 'variables.js'));
+
+    const result = runVariables({});
+
+    expect(result.status).toBe(0);
+    const final = readFileSync(join(dir, 'variables-final.js'), 'utf8');
+    expect(final).not.toMatch(/__BACKGROUND__|__END__|__TITLE__/);
+    expect(final).toContain("window.background = '';");
+  });
+
+  it('fails loudly when the variables.js template is missing', () => {
+    const result = runVariables({ TIMER_TARGET: '2026-12-31T23:59:59Z' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('[variables.sh] ERROR: cannot copy');
+    expect(existsSync(join(dir, 'variables-final.js'))).toBe(false);
+  });
+});

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,7 +1,7 @@
 services:
   web:
     stdin_open: true # So that the serving is not exited with code 0
-    image: yooooomi/easy-countdown
+    image: yiddy/simple-countdown
     environment:
       TIMER_BACKGROUND: https://wallpaperplay.com/walls/full/0/7/6/29912.jpg
       TIMER_TARGET: 'Fri Oct 01 2021 15:33:36 GMT+0200' # Get help with https://esqsoft.com/javascript_examples/date-to-epoch.htm

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,3 +8,9 @@ services:
       TIMER_TITLE: 'My next birthday'
     ports:
       - '3000:3000'
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,9 @@ services:
       TIMER_TITLE: 'My birthday in'
     ports:
       - '3000:3000'
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,27 @@
 #!/bin/sh
 set -e
 
+echo "[entrypoint] simple-countdown container starting"
+
 # Inject TIMER_* env vars into variables-final.js at container start,
 # so one prebuilt image is configured per-deployment.
-/variables.sh /usr/share/nginx/html
+if /variables.sh /usr/share/nginx/html; then
+    echo "[entrypoint] runtime configuration injected"
+else
+    status=$?
+    echo "[entrypoint] ERROR: variables.sh failed with exit code $status" >&2
+    exit "$status"
+fi
 
+# Presence only - values may be long or sensitive
+for name in TIMER_BACKGROUND TIMER_TARGET TIMER_TITLE; do
+    eval "value=\${$name:-}"
+    if [ -n "$value" ]; then
+        echo "[entrypoint] $name set"
+    else
+        echo "[entrypoint] $name not set"
+    fi
+done
+
+echo "[entrypoint] starting nginx"
 exec nginx -g 'daemon off;'

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,4 +6,18 @@ server {
     location / {
         try_files $uri /index.html;
     }
+
+    # Vite content-hashed bundles: safe to cache forever
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # Rewritten at container start (variables.sh) / per deployment: never cache long-term
+    location = /variables-final.js {
+        add_header Cache-Control "no-cache";
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,13 +26,16 @@ importers:
         version: 10.0.1(semantic-release@25.0.7(typescript@6.0.3))
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@8.1.5(jiti@2.7.0))
+        version: 4.3.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -41,7 +44,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.5(jiti@2.7.0))
+        version: 6.0.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
       eslint:
         specifier: ^9.39.5
         version: 9.39.5(jiti@2.7.0)
@@ -80,10 +83,10 @@ importers:
         version: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(jiti@2.7.0)
+        version: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(jsdom@29.1.1)(vite@8.1.5(jiti@2.7.0))
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
 
 packages:
 
@@ -677,6 +680,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2846,6 +2852,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
@@ -3667,12 +3676,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/vite@4.3.3(vite@8.1.5(jiti@2.7.0))':
+  '@tailwindcss/vite@4.3.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 8.1.5(jiti@2.7.0)
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -3721,6 +3730,10 @@ snapshots:
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -3823,10 +3836,10 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.5(jiti@2.7.0))':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.5(jiti@2.7.0)
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3837,13 +3850,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(jiti@2.7.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(jiti@2.7.0)
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -6049,6 +6062,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@8.3.0: {}
+
   undici@6.27.0: {}
 
   undici@7.28.0: {}
@@ -6088,7 +6103,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@8.1.5(jiti@2.7.0):
+  vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -6096,13 +6111,14 @@ snapshots:
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.10(jsdom@29.1.1)(vite@8.1.5(jiti@2.7.0)):
+  vitest@4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(jiti@2.7.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -6119,9 +6135,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5(jiti@2.7.0)
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 26.1.1
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "isolatedModules": true,
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "__tests__", "vite.config.ts"]
 }

--- a/variables.sh
+++ b/variables.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-cp $1/variables.js $1/variables-final.js
+dir=$1
 
-sed -i -e "s@__BACKGROUND__@$TIMER_BACKGROUND@g" $1/variables-final.js
-sed -i -e "s@__END__@$TIMER_TARGET@g" $1/variables-final.js
-sed -i -e "s@__TITLE__@$TIMER_TITLE@g" $1/variables-final.js
+cp "$dir/variables.js" "$dir/variables-final.js" || {
+    echo "[variables.sh] ERROR: cannot copy $dir/variables.js to $dir/variables-final.js" >&2
+    exit 1
+}
+
+for pair in "__BACKGROUND__=$TIMER_BACKGROUND" "__END__=$TIMER_TARGET" "__TITLE__=$TIMER_TITLE"; do
+    placeholder=${pair%%=*}
+    value=${pair#*=}
+    sed -i -e "s@$placeholder@$value@g" "$dir/variables-final.js" || {
+        echo "[variables.sh] ERROR: substitution of $placeholder failed" >&2
+        exit 1
+    }
+done
+
+echo "[variables.sh] substituted TIMER_* placeholders into $dir/variables-final.js"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   server: { port: 3000 },
   test: {
     environment: 'jsdom',
-    include: ['src/**/__tests__/**/*.test.ts?(x)'],
+    include: ['src/**/__tests__/**/*.test.ts?(x)', '__tests__/**/*.test.ts'],
     setupFiles: ['src/test/setup.ts'],
   },
 });


### PR DESCRIPTION
Implements the "Now"-priority ops items from the post-modernization roadmap #148 (Milestone 4: 4.1, 4.2, 4.3), plus operational logging improvements. Rebased onto master after #151 (Testing Library + jsdom component tests) merged.

## 4.1 — Pin GitHub Actions to commit SHAs (`chore(ci)`)

All 30 `uses:` lines across the 8 workflow files now reference the full 40-char commit SHA their tag currently points to, with a trailing `# vX.Y.Z` comment (e.g. `actions/checkout@9c091bb… # v7.0.0`). SHAs were resolved with `git ls-remote` against each action repo — for annotated tags (pnpm/action-setup, github/codeql-action, actions/github-script) the peeled `^{}` commit SHA is used, not the tag object. The commented-out `actions/setup-example@v1` doc example in codeql.yml was left as-is. Dependabot's existing `github-actions` ecosystem keeps the pins updated.

## 4.2 — Docker healthcheck (`chore(docker)`)

- `HEALTHCHECK CMD wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1` in the runtime stage. Verified against the actual `nginx:alpine-slim` base that `wget` is a busybox applet (`/usr/bin/wget`) — no packages added.
- Matching `healthcheck:` blocks in `docker-compose.yml` and `docker-compose.production.yml` (30s interval, 5s timeout, 3 retries, 5s start period).
- `docker-compose.dev.yml` intentionally unchanged: it's an override on top of `docker-compose.yml`, so it inherits the healthcheck — which works there too, since the dev container runs Vite on :3000 and node:24-alpine's busybox also provides wget.

## 4.3 — nginx cache headers

- `/assets/` (Vite content-hashed bundles): `Cache-Control: public, max-age=31536000, immutable`
- `/variables-final.js` and `/index.html` (rewritten per deployment/container start): `Cache-Control: no-cache`
- The existing `try_files $uri /index.html;` fallback is untouched; its internal redirect re-enters location matching, so SPA-fallback responses on `/` also get `no-cache` (verified).

## Logging additions (not in the roadmap text)

- `docker-entrypoint.sh` now logs container start, injection success, and — presence only, never values — whether each `TIMER_*` variable is set. If `variables.sh` fails, the exit code is logged to stderr before the container exits instead of dying silently under `set -e`.
- `variables.sh` logs a success line after substitution and a specific error (to stderr, non-zero exit) for the step that failed. Both scripts remain POSIX sh with exec bits and LF endings preserved.
- nginx access/error logs: confirmed `nginx:alpine-slim` still symlinks `/var/log/nginx/{access,error}.log` to `/dev/stdout`/`/dev/stderr`, so no config changes were needed — `docker logs` already shows them.
- README: new **Logs** section documenting `docker logs` / `docker compose logs`, what gets logged, and `docker inspect --format '{{json .State.Health}}'` for healthcheck status.

## Production compose image fix (requested in PR discussion)

`docker-compose.production.yml` referenced the upstream fork-parent image `yooooomi/easy-countdown`; it now points at this project's published `yiddy/simple-countdown` image.

## Tests

Per the same-commit rule added in #151, `__tests__/Variables.test.ts` ships in the `chore(docker)` commit and covers the `variables.sh` changes by spawning the real script against a temp copy of `public/variables.js`: substitution with all `TIMER_*` values set, empty-env substitution (placeholders → empty strings), and the missing-template failure path (exit 1, `[variables.sh] ERROR` on stderr). Supporting infra: `test.include` extended for the root `__tests__/` dir, tsconfig now includes it, and `@types/node` added for the node API typings (test runs `// @vitest-environment node`; skipped on Windows since it needs POSIX sh). The other changes have no unit-test surface — workflow pins, HEALTHCHECK, compose blocks, and nginx headers are covered by the end-to-end Docker verification below.

## Verification

- `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (20/20: Date + Home + new Variables suites), `pnpm build` — all pass after the rebase.
- Built the image and ran it with `TIMER_TARGET`/`TIMER_TITLE` set: `docker logs` shows the entrypoint summary + nginx access logs; healthcheck reports `healthy` (probe exit 0); `curl -I` confirms `immutable` on `/assets/*.js` and `no-cache` on `/`, `/index.html`, `/variables-final.js`; substituted `variables-final.js` served correctly. Failure path tested (missing `variables.js`): clear error lines, exit 1. (Sandbox note: the test build used a build-stage-only tweak because this environment's egress proxy blocks the alpine package CDN; the runtime stage under test is byte-identical to this Dockerfile.)
- `docker compose config` validates all three compose files, including the merged dev override.

Closes nothing on its own; part of #148 (items 4.1, 4.2, 4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mz4FXkPhUWr3iZn6RK4L7u