### PR TITLE
feat: add configurable countdown completion behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,33 @@ Simple countdown is an easy to setup countdown page. Can be setup as a countdown
 
 If you use docker, just edit the `docker-compose.yml` file so that it fits your needs.
 
-| Variables        | Definition                                                                                                  | Example                                              |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| TIMER_BACKGROUND | The url of an image that will be used for as background                                                     | https://wallpaperplay.com/walls/full/0/7/6/29912.jpg |
-| TIMER_TARGET     | The target date of the countdown, if date is in the future, timer will decrease, otherwise it will increase | Fri Oct 01 2021 15:33:36 GMT+0200                    |
-| TIMER_TITLE      | The title of the countdown, can be empty                                                                    | My title!                                            |
+| Variables               | Definition                                                                                                             | Example                                              |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| TIMER_BACKGROUND        | The url of an image that will be used for as background                                                                | https://wallpaperplay.com/walls/full/0/7/6/29912.jpg |
+| TIMER_TARGET            | The target date of the countdown                                                                                       | Fri Oct 01 2021 15:33:36 GMT+0200                    |
+| TIMER_TITLE             | The title of the countdown, can be empty                                                                               | My title!                                            |
+| TIMER_DONE_MESSAGE      | Text shown when the countdown reaches zero (default `The wait is over!`)                                               | Happy new year!                                      |
+| TIMER_DONE_COUNTUP      | `true`/`false` (default `false`) — keep counting up past zero instead of freezing; all other TIMER_DONE_\* are ignored | true                                                 |
+| TIMER_DONE_ANIMATION    | `true`/`false` (default `false`) — play a pulse animation on the completion message (skipped for reduced motion users) | true                                                 |
+| TIMER_DONE_HIDE_TIMER   | `true`/`false` (default `false`) — hide the frozen `00 00 00 00` blocks at zero and show only the message              | true                                                 |
+| TIMER_DONE_RELOAD       | `true`/`false` (default `false`) — reload the page after the done state has been visible for TIMER_DONE_DELAY_MS       | true                                                 |
+| TIMER_DONE_REDIRECT_URL | http(s) URL to navigate to after the done state has been visible for TIMER_DONE_DELAY_MS; ignored if invalid           | https://example.com/live                             |
+| TIMER_DONE_DELAY_MS     | How long (ms, default `3000`) the done state stays visible before TIMER_DONE_RELOAD / TIMER_DONE_REDIRECT_URL fires    | 5000                                                 |
 
 Variables are injected at **container start**, so one prebuilt image can be configured per deployment.
+
+### When the countdown reaches zero
+
+By default the timer freezes at `00 00 00 00` and shows `TIMER_DONE_MESSAGE`. The `TIMER_DONE_*`
+flags are independent and combinable (e.g. message + animation + delayed redirect), with these rules:
+
+1. `TIMER_DONE_COUNTUP=true` — the timer just keeps counting up past zero (the historical behavior);
+   every other `TIMER_DONE_*` variable is ignored.
+2. Otherwise the timer freezes the instant the target passes and the message is shown
+   (`TIMER_DONE_ANIMATION` animates it, `TIMER_DONE_HIDE_TIMER` hides the frozen blocks).
+3. If both `TIMER_DONE_RELOAD` and a valid `TIMER_DONE_REDIRECT_URL` are set, the redirect wins;
+   the reload only fires when the redirect URL is unset or invalid.
+4. If neither reload nor redirect is set, the done state stays visible indefinitely.
 
 ### Example of `docker-compose.yml` file
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,7 +14,9 @@ else
 fi
 
 # Presence only - values may be long or sensitive
-for name in TIMER_BACKGROUND TIMER_TARGET TIMER_TITLE; do
+for name in TIMER_BACKGROUND TIMER_TARGET TIMER_TITLE TIMER_DONE_MESSAGE TIMER_DONE_COUNTUP \
+    TIMER_DONE_ANIMATION TIMER_DONE_HIDE_TIMER TIMER_DONE_RELOAD TIMER_DONE_REDIRECT_URL \
+    TIMER_DONE_DELAY_MS; do
     eval "value=\${$name:-}"
     if [ -n "$value" ]; then
         echo "[entrypoint] $name set"

--- a/public/variables.js
+++ b/public/variables.js
@@ -1,3 +1,10 @@
 window.background = '__BACKGROUND__';
 window.target = new Date('__END__');
 window.title = '__TITLE__' || '';
+window.doneMessage = '__DONE_MESSAGE__' || '';
+window.doneCountup = '__DONE_COUNTUP__' === 'true';
+window.doneAnimation = '__DONE_ANIMATION__' === 'true';
+window.doneHideTimer = '__DONE_HIDE_TIMER__' === 'true';
+window.doneReload = '__DONE_RELOAD__' === 'true';
+window.doneRedirectUrl = '__DONE_REDIRECT_URL__' || '';
+window.doneDelayMs = Number('__DONE_DELAY_MS__' || '3000');

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,22 @@
 
 @theme {
   --font-sans: 'Balsamiq Sans', ui-sans-serif, system-ui, sans-serif;
+  --animate-done-pulse: done-pulse 600ms ease-out both;
+
+  @keyframes done-pulse {
+    0% {
+      opacity: 0;
+      transform: scale(0.9);
+    }
+    60% {
+      opacity: 1;
+      transform: scale(1.05);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
 }
 
 @layer base {

--- a/src/scenes/Home/__tests__/Home.test.tsx
+++ b/src/scenes/Home/__tests__/Home.test.tsx
@@ -1,5 +1,14 @@
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_DONE_MESSAGE } from '../../../service/completion';
+
+// jsdom's window.location is unforgeable, so Home navigates through this
+// module; vi.hoisted keeps the same mock instances across vi.resetModules().
+const navigationMock = vi.hoisted(() => ({
+  reloadPage: vi.fn(),
+  redirectTo: vi.fn(),
+}));
+vi.mock('../../../service/navigation', () => navigationMock);
 
 const base = new Date('2030-01-01T00:00:00.000Z');
 
@@ -14,14 +23,40 @@ interface HomeGlobals {
   target: Date;
   title?: string;
   background?: string;
+  doneMessage?: string;
+  doneCountup?: boolean;
+  doneAnimation?: boolean;
+  doneHideTimer?: boolean;
+  doneReload?: boolean;
+  doneRedirectUrl?: string;
+  doneDelayMs?: number;
 }
 
 // Home resolves window.target at module scope, so the globals must be in place
 // before the module is (re-)imported — hence resetModules + dynamic import.
-async function renderHome({ target, title = '', background = 'background.jpg' }: HomeGlobals) {
+// Defaults mirror public/variables.js with no TIMER_* env vars set.
+async function renderHome({
+  target,
+  title = '',
+  background = 'background.jpg',
+  doneMessage = '',
+  doneCountup = false,
+  doneAnimation = false,
+  doneHideTimer = false,
+  doneReload = false,
+  doneRedirectUrl = '',
+  doneDelayMs = 3000,
+}: HomeGlobals) {
   window.target = target;
   window.title = title;
   window.background = background;
+  window.doneMessage = doneMessage;
+  window.doneCountup = doneCountup;
+  window.doneAnimation = doneAnimation;
+  window.doneHideTimer = doneHideTimer;
+  window.doneReload = doneReload;
+  window.doneRedirectUrl = doneRedirectUrl;
+  window.doneDelayMs = doneDelayMs;
   vi.resetModules();
   const { default: Home } = await import('../index');
   const result = render(<Home />);
@@ -57,12 +92,14 @@ function tick(ms: number) {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   vi.useFakeTimers();
   vi.setSystemTime(base);
 });
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 describe('Home', () => {
@@ -113,14 +150,15 @@ describe('Home', () => {
     }
   });
 
-  it('counts up once the target has passed (current behavior)', async () => {
-    await renderHome({ target: new Date(base.getTime() - 2 * SECOND) });
+  it('keeps counting up past the target when TIMER_DONE_COUNTUP is set', async () => {
+    await renderHome({ target: new Date(base.getTime() - 2 * SECOND), doneCountup: true });
 
     expect(blockDigits('seconds')).toBe('02');
 
     tick(1000);
 
     expect(blockDigits('seconds')).toBe('03');
+    expect(screen.queryByText(DEFAULT_DONE_MESSAGE)).not.toBeInTheDocument();
   });
 
   it('sets document.title from window.title and renders it as the heading', async () => {
@@ -138,5 +176,114 @@ describe('Home', () => {
 
     expect(document.title).toBe('Easy countdown');
     expect(screen.queryByText('Easy countdown')).not.toBeInTheDocument();
+  });
+
+  it('freezes at 00 00 00 00 with the completion message when the target passes', async () => {
+    await renderHome({ target: new Date(base.getTime() + SECOND), title: 'T-minus' });
+
+    expect(screen.getByText('T-minus')).toBeInTheDocument();
+
+    tick(1000);
+
+    // The message replaces the title; the interval is stopped, so further
+    // ticks must not count back up.
+    expect(screen.getByText(DEFAULT_DONE_MESSAGE)).toBeInTheDocument();
+    expect(screen.queryByText('T-minus')).not.toBeInTheDocument();
+    tick(5000);
+    for (const label of labelTexts()) {
+      expect(blockDigits(label)).toBe('00');
+    }
+  });
+
+  it('shows a custom TIMER_DONE_MESSAGE', async () => {
+    await renderHome({
+      target: new Date(base.getTime() - SECOND),
+      doneMessage: 'Happy launch day!',
+    });
+
+    expect(screen.getByText('Happy launch day!')).toBeInTheDocument();
+  });
+
+  it('hides the blocks in the done state when TIMER_DONE_HIDE_TIMER is set', async () => {
+    await renderHome({ target: new Date(base.getTime() - SECOND), doneHideTimer: true });
+
+    expect(screen.getByText(DEFAULT_DONE_MESSAGE)).toBeInTheDocument();
+    expect(screen.queryByText(LABEL_PATTERN)).not.toBeInTheDocument();
+  });
+
+  it('applies the pulse animation class only when TIMER_DONE_ANIMATION is set', async () => {
+    const animated = await renderHome({
+      target: new Date(base.getTime() - SECOND),
+      doneAnimation: true,
+    });
+    expect(screen.getByText(DEFAULT_DONE_MESSAGE)).toHaveClass('motion-safe:animate-done-pulse');
+    animated.unmount();
+
+    await renderHome({ target: new Date(base.getTime() - SECOND) });
+    expect(screen.getByText(DEFAULT_DONE_MESSAGE)).not.toHaveClass(
+      'motion-safe:animate-done-pulse',
+    );
+  });
+
+  it('reloads after the configured delay when TIMER_DONE_RELOAD is set', async () => {
+    await renderHome({
+      target: new Date(base.getTime() + SECOND),
+      doneReload: true,
+      doneDelayMs: 2000,
+    });
+
+    tick(1000);
+    expect(navigationMock.reloadPage).not.toHaveBeenCalled();
+
+    tick(1999);
+    expect(navigationMock.reloadPage).not.toHaveBeenCalled();
+
+    tick(1);
+    expect(navigationMock.reloadPage).toHaveBeenCalledOnce();
+  });
+
+  it('redirects instead of reloading when both are configured', async () => {
+    await renderHome({
+      target: new Date(base.getTime() + SECOND),
+      doneReload: true,
+      doneRedirectUrl: 'https://example.com/live',
+    });
+
+    tick(1000);
+    tick(3000);
+
+    expect(navigationMock.redirectTo).toHaveBeenCalledExactlyOnceWith('https://example.com/live');
+    expect(navigationMock.reloadPage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to reload when the redirect URL is invalid', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await renderHome({
+      target: new Date(base.getTime() + SECOND),
+      doneReload: true,
+      doneRedirectUrl: 'not a url',
+    });
+
+    tick(1000);
+    tick(3000);
+
+    expect(warn).toHaveBeenCalled();
+    expect(navigationMock.redirectTo).not.toHaveBeenCalled();
+    expect(navigationMock.reloadPage).toHaveBeenCalledOnce();
+  });
+
+  it('never reloads or redirects in countup mode', async () => {
+    await renderHome({
+      target: new Date(base.getTime() - SECOND),
+      doneCountup: true,
+      doneReload: true,
+      doneRedirectUrl: 'https://example.com/live',
+    });
+
+    tick(10_000);
+
+    expect(navigationMock.reloadPage).not.toHaveBeenCalled();
+    expect(navigationMock.redirectTo).not.toHaveBeenCalled();
   });
 });

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -1,29 +1,71 @@
 import { useEffect, useState, useMemo } from 'react';
 import { describe } from '../../service/date';
 import { resolveTarget } from '../../service/target';
+import { resolveCompletion } from '../../service/completion';
+import { redirectTo, reloadPage } from '../../service/navigation';
 import Block from './Block';
 
 const end = resolveTarget(window.target);
+const completion = resolveCompletion({
+  countup: window.doneCountup,
+  message: window.doneMessage,
+  animate: window.doneAnimation,
+  hideTimer: window.doneHideTimer,
+  reload: window.doneReload,
+  redirectUrl: window.doneRedirectUrl,
+  delayMs: window.doneDelayMs,
+});
+
+const headingClasses = 'mb-4 text-center text-3xl text-white sm:mb-6 sm:text-4xl lg:text-5xl';
 
 function Home() {
   const [date, setDate] = useState(new Date());
 
+  // In countup mode there is no done state: the timer runs forever.
+  const doneState =
+    end !== null && completion.mode === 'freeze' && date.getTime() >= end.getTime()
+      ? completion
+      : null;
+  const done = doneState !== null;
+
   useEffect(() => {
     document.title = window.title || 'Easy countdown';
+    if (done) {
+      return;
+    }
     const inter = setInterval(() => {
       setDate(new Date());
     }, 1000);
     return () => {
       clearInterval(inter);
     };
-  }, []);
+  }, [done]);
+
+  useEffect(() => {
+    if (!done || completion.mode !== 'freeze' || completion.followUp === null) {
+      return;
+    }
+    const { followUp } = completion;
+    const timeout = setTimeout(() => {
+      if (followUp.action === 'redirect') {
+        redirectTo(followUp.url);
+      } else {
+        reloadPage();
+      }
+    }, followUp.delayMs);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [done]);
 
   const described = useMemo(() => {
     if (end === null) {
       return null;
     }
-    return describe(date, end);
-  }, [date]);
+    // Freeze at exactly 00 00 00 00 once done; describe() otherwise counts
+    // back up past the target (countup mode relies on that).
+    return describe(done ? end : date, end);
+  }, [date, done]);
 
   return (
     <div
@@ -33,29 +75,34 @@ function Home() {
       <div className="flex flex-col items-center px-4">
         {described === null ? (
           <>
-            <div className="mb-4 text-center text-3xl text-white sm:mb-6 sm:text-4xl lg:text-5xl">
-              No valid countdown target configured
-            </div>
+            <div className={headingClasses}>No valid countdown target configured</div>
             <div className="text-center text-base text-white opacity-80">
               Set TIMER_TARGET to an ISO 8601 date, e.g. 2026-12-31T23:59:59
             </div>
           </>
         ) : (
           <>
-            {window.title && window.title.length > 0 && (
-              <div className="mb-4 text-center text-3xl text-white sm:mb-6 sm:text-4xl lg:text-5xl">
-                {window.title}
+            {doneState !== null ? (
+              <div
+                className={`${headingClasses}${doneState.animate ? ' motion-safe:animate-done-pulse' : ''}`}
+              >
+                {doneState.message}
+              </div>
+            ) : (
+              window.title &&
+              window.title.length > 0 && <div className={headingClasses}>{window.title}</div>
+            )}
+            {!(doneState !== null && doneState.hideTimer) && (
+              <div className="flex flex-wrap items-start justify-center gap-3 sm:gap-4">
+                {Object.entries(described).map(([key, value]) => (
+                  <Block
+                    key={key}
+                    title={`${key}${value > 1 ? 's' : ''}`}
+                    value={value.toString().padStart(2, '0')}
+                  />
+                ))}
               </div>
             )}
-            <div className="flex flex-wrap items-start justify-center gap-3 sm:gap-4">
-              {Object.entries(described).map(([key, value]) => (
-                <Block
-                  key={key}
-                  title={`${key}${value > 1 ? 's' : ''}`}
-                  value={value.toString().padStart(2, '0')}
-                />
-              ))}
-            </div>
           </>
         )}
       </div>

--- a/src/service/__tests__/Date.test.ts
+++ b/src/service/__tests__/Date.test.ts
@@ -22,6 +22,11 @@ describe('describe', () => {
     expect(describeDuration(base, base)).toEqual({ day: 0, hour: 0, minute: 0, second: 0 });
   });
 
+  it('counts back up after the target has passed', () => {
+    const target = offset(-(1 * HOUR + 30 * MINUTE));
+    expect(describeDuration(base, target)).toEqual({ day: 0, hour: 1, minute: 30, second: 0 });
+  });
+
   it('is symmetric in its arguments', () => {
     const target = offset(5 * DAY + 6 * HOUR);
     expect(describeDuration(base, target)).toEqual(describeDuration(target, base));

--- a/src/service/__tests__/completion.test.ts
+++ b/src/service/__tests__/completion.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_DONE_DELAY_MS,
+  DEFAULT_DONE_MESSAGE,
+  resolveCompletion,
+  type CompletionFlags,
+} from '../completion';
+
+// Mirrors public/variables.js defaults when no TIMER_DONE_* env var is set.
+function flags(overrides: Partial<CompletionFlags> = {}): CompletionFlags {
+  return {
+    countup: false,
+    message: '',
+    animate: false,
+    hideTimer: false,
+    reload: false,
+    redirectUrl: '',
+    delayMs: DEFAULT_DONE_DELAY_MS,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveCompletion', () => {
+  it('defaults to freezing with the default message and no follow-up', () => {
+    expect(resolveCompletion(flags())).toEqual({
+      mode: 'freeze',
+      message: DEFAULT_DONE_MESSAGE,
+      animate: false,
+      hideTimer: false,
+      followUp: null,
+    });
+  });
+
+  it('counts up when countup is set, ignoring every other flag', () => {
+    expect(
+      resolveCompletion(
+        flags({
+          countup: true,
+          message: 'Ignored',
+          animate: true,
+          hideTimer: true,
+          reload: true,
+          redirectUrl: 'https://example.com/',
+        }),
+      ),
+    ).toEqual({ mode: 'countup' });
+  });
+
+  it('passes a custom message through', () => {
+    expect(resolveCompletion(flags({ message: 'Happy new year!' }))).toMatchObject({
+      message: 'Happy new year!',
+    });
+  });
+
+  it("treats a raw '__DONE_MESSAGE__' placeholder as unset", () => {
+    expect(resolveCompletion(flags({ message: '__DONE_MESSAGE__' }))).toMatchObject({
+      message: DEFAULT_DONE_MESSAGE,
+    });
+  });
+
+  it('passes the animate and hideTimer flags through', () => {
+    expect(resolveCompletion(flags({ animate: true, hideTimer: true }))).toMatchObject({
+      animate: true,
+      hideTimer: true,
+    });
+  });
+
+  it('schedules a reload when only reload is set', () => {
+    expect(resolveCompletion(flags({ reload: true }))).toMatchObject({
+      followUp: { action: 'reload', delayMs: DEFAULT_DONE_DELAY_MS },
+    });
+  });
+
+  it('schedules a redirect for a valid URL', () => {
+    expect(resolveCompletion(flags({ redirectUrl: 'https://example.com/live' }))).toMatchObject({
+      followUp: { action: 'redirect', url: 'https://example.com/live', delayMs: 3000 },
+    });
+  });
+
+  it('redirect wins when both reload and a valid redirect URL are set', () => {
+    expect(
+      resolveCompletion(flags({ reload: true, redirectUrl: 'https://example.com/live' })),
+    ).toMatchObject({
+      followUp: { action: 'redirect', url: 'https://example.com/live' },
+    });
+  });
+
+  it('ignores an invalid redirect URL with a warning and falls back to reload', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(resolveCompletion(flags({ reload: true, redirectUrl: 'not a url' }))).toMatchObject({
+      followUp: { action: 'reload' },
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a non-http(s) redirect URL', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(resolveCompletion(flags({ redirectUrl: 'javascript:alert(1)' }))).toMatchObject({
+      followUp: null,
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("treats a raw '__DONE_REDIRECT_URL__' placeholder as unset without warning", () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(resolveCompletion(flags({ redirectUrl: '__DONE_REDIRECT_URL__' }))).toMatchObject({
+      followUp: null,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('respects a custom delay', () => {
+    expect(resolveCompletion(flags({ reload: true, delayMs: 250 }))).toMatchObject({
+      followUp: { action: 'reload', delayMs: 250 },
+    });
+  });
+
+  it('falls back to the default delay for NaN or negative values', () => {
+    // NaN mirrors public/variables.js when the raw __DONE_DELAY_MS__ placeholder survives.
+    expect(resolveCompletion(flags({ reload: true, delayMs: Number.NaN }))).toMatchObject({
+      followUp: { action: 'reload', delayMs: DEFAULT_DONE_DELAY_MS },
+    });
+    expect(resolveCompletion(flags({ reload: true, delayMs: -1 }))).toMatchObject({
+      followUp: { action: 'reload', delayMs: DEFAULT_DONE_DELAY_MS },
+    });
+  });
+});

--- a/src/service/completion.ts
+++ b/src/service/completion.ts
@@ -1,0 +1,89 @@
+// Resolves the TIMER_DONE_* runtime flags into what should happen when the
+// countdown reaches zero. Pure and DOM-free: Home performs the actual side
+// effects (interval control, delay timeout, navigation).
+//
+// Precedence rules:
+// 1. countup=true: the timer keeps ticking upward past zero (the historical
+//    behavior, made explicit). Every other done flag is ignored — with no
+//    discrete "done" moment there is nothing to attach a message, animation,
+//    reload or redirect to.
+// 2. Otherwise the timer freezes at 00 00 00 00 the instant the target
+//    passes; the message is shown (replacing the blocks entirely when
+//    hideTimer is set) and the animation plays if enabled.
+// 3. If both reload and a valid redirect URL are set, redirect wins. Reload
+//    only fires when the redirect URL is unset or invalid.
+// 4. If neither is set, the done state stays visible indefinitely.
+
+export const DEFAULT_DONE_MESSAGE = 'The wait is over!';
+export const DEFAULT_DONE_DELAY_MS = 3000;
+
+export interface CompletionFlags {
+  countup: boolean;
+  message: string;
+  animate: boolean;
+  hideTimer: boolean;
+  reload: boolean;
+  redirectUrl: string;
+  delayMs: number;
+}
+
+export type CompletionFollowUp =
+  { action: 'reload'; delayMs: number } | { action: 'redirect'; url: string; delayMs: number };
+
+export type CompletionBehavior =
+  | { mode: 'countup' }
+  | {
+      mode: 'freeze';
+      message: string;
+      animate: boolean;
+      hideTimer: boolean;
+      followUp: CompletionFollowUp | null;
+    };
+
+// An empty value or a raw __PLACEHOLDER__ (variables.sh never ran) counts as unset.
+function provided(raw: string): string | null {
+  return raw === '' || /^__.*__$/.test(raw) ? null : raw;
+}
+
+function resolveRedirectUrl(raw: string): string | null {
+  const candidate = provided(raw);
+  if (candidate === null) {
+    return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    console.warn(`Ignoring invalid TIMER_DONE_REDIRECT_URL "${candidate}": not a valid URL`);
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    console.warn(`Ignoring invalid TIMER_DONE_REDIRECT_URL "${candidate}": must be http(s)`);
+    return null;
+  }
+  return candidate;
+}
+
+export function resolveCompletion(flags: CompletionFlags): CompletionBehavior {
+  if (flags.countup) {
+    return { mode: 'countup' };
+  }
+
+  const delayMs =
+    Number.isFinite(flags.delayMs) && flags.delayMs >= 0 ? flags.delayMs : DEFAULT_DONE_DELAY_MS;
+  const redirectUrl = resolveRedirectUrl(flags.redirectUrl);
+  const followUp: CompletionFollowUp | null =
+    redirectUrl !== null
+      ? { action: 'redirect', url: redirectUrl, delayMs }
+      : flags.reload
+        ? { action: 'reload', delayMs }
+        : null;
+
+  return {
+    mode: 'freeze',
+    message: provided(flags.message) ?? DEFAULT_DONE_MESSAGE,
+    animate: flags.animate,
+    hideTimer: flags.hideTimer,
+    followUp,
+  };
+}

--- a/src/service/navigation.ts
+++ b/src/service/navigation.ts
@@ -1,0 +1,9 @@
+// Thin wrappers around window.location so component tests can mock this
+// module — jsdom's Location properties are unforgeable and cannot be spied on.
+export function reloadPage(): void {
+  window.location.reload();
+}
+
+export function redirectTo(url: string): void {
+  window.location.assign(url);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,4 +5,11 @@ declare interface Window {
   background: string;
   target: Date;
   title: string;
+  doneMessage: string;
+  doneCountup: boolean;
+  doneAnimation: boolean;
+  doneHideTimer: boolean;
+  doneReload: boolean;
+  doneRedirectUrl: string;
+  doneDelayMs: number;
 }

--- a/variables.sh
+++ b/variables.sh
@@ -7,7 +7,11 @@ cp "$dir/variables.js" "$dir/variables-final.js" || {
     exit 1
 }
 
-for pair in "__BACKGROUND__=$TIMER_BACKGROUND" "__END__=$TIMER_TARGET" "__TITLE__=$TIMER_TITLE"; do
+for pair in "__BACKGROUND__=$TIMER_BACKGROUND" "__END__=$TIMER_TARGET" "__TITLE__=$TIMER_TITLE" \
+    "__DONE_MESSAGE__=$TIMER_DONE_MESSAGE" "__DONE_COUNTUP__=$TIMER_DONE_COUNTUP" \
+    "__DONE_ANIMATION__=$TIMER_DONE_ANIMATION" "__DONE_HIDE_TIMER__=$TIMER_DONE_HIDE_TIMER" \
+    "__DONE_RELOAD__=$TIMER_DONE_RELOAD" "__DONE_REDIRECT_URL__=$TIMER_DONE_REDIRECT_URL" \
+    "__DONE_DELAY_MS__=$TIMER_DONE_DELAY_MS"; do
     placeholder=${pair%%=*}
     value=${pair#*=}
     sed -i -e "s@$placeholder@$value@g" "$dir/variables-final.js" || {


### PR DESCRIPTION
## Summary

`describe()` in `src/service/date.ts` uses `Math.abs`, so once `TIMER_TARGET` passes, the timer silently counts back **up** from zero with no signal the event happened. This implements roadmap item **1.2** of #148 and subsumes/closes #16 (auto-reload) and #17 (redirect).

Closes #16
Closes #17

### Design note — supersedes the `TIMER_DONE_ACTION` sketch in #148

#148's original sketch proposed a single exclusive `TIMER_DONE_ACTION` enum (`stop` | `countup` | `reload` | `redirect`). This PR uses **independent, combinable flags** instead, since reaching zero is one moment but the desired follow-up behaviors aren't mutually exclusive (e.g. show a message with an animation, wait a few seconds, *then* redirect).

New runtime env vars (same `variables.sh`/`variables.js`/`vite-env.d.ts` injection pattern as the existing `TIMER_*` vars — never `import.meta.env`):

| Variable | Default | Effect |
|---|---|---|
| `TIMER_DONE_MESSAGE` | `The wait is over!` | Text shown when the countdown reaches zero |
| `TIMER_DONE_COUNTUP` | `false` | Keep counting up past zero instead of freezing (today's historical behavior, now an explicit opt-in) |
| `TIMER_DONE_ANIMATION` | `false` | CSS-only pulse on the completion message (Tailwind `motion-safe:` variant — skipped under `prefers-reduced-motion`) |
| `TIMER_DONE_HIDE_TIMER` | `false` | Hide the frozen `00 00 00 00` blocks, showing only the message |
| `TIMER_DONE_RELOAD` | `false` | Reload the page after the done state has been visible for `TIMER_DONE_DELAY_MS` |
| `TIMER_DONE_REDIRECT_URL` | unset | http(s) URL to navigate to after the delay; invalid URLs are ignored with a `console.warn` and fall back as if unset |
| `TIMER_DONE_DELAY_MS` | `3000` | How long the done state is visible before reload/redirect fires |

### Precedence rules (documented in `src/service/completion.ts`)

1. `TIMER_DONE_COUNTUP=true` — timer just keeps counting up past zero; **every other** `TIMER_DONE_*` flag is ignored (no discrete "done" moment to attach a message/animation/reload/redirect to).
2. Otherwise the timer freezes the instant the target passes: message shown, animation plays if enabled, blocks hidden if `TIMER_DONE_HIDE_TIMER` is set.
3. If both `TIMER_DONE_RELOAD` and a **valid** `TIMER_DONE_REDIRECT_URL` are set, redirect wins (matches #17's originally requested override behavior). Reload only fires when the redirect is unset/invalid.
4. If neither reload nor redirect is set, the done state just stays visible indefinitely.

## Implementation

- `src/service/completion.ts` — pure, DOM-free `resolveCompletion()` implementing the precedence rules above; fully unit tested.
- `src/service/navigation.ts` — thin `window.location` wrapper so `Home`'s reload/redirect side effects are mockable under jsdom (`window.location` properties aren't spyable directly).
- `src/scenes/Home/index.tsx` — computes the done state once the target resolves (reusing `resolveTarget`), stops the interval when frozen, renders the completion view, and schedules the reload/redirect timeout per the precedence rules (cleaned up on unmount).
- `src/index.css` — CSS-only `done-pulse` keyframe animation, applied via `motion-safe:animate-done-pulse`.
- README updated with the new env var table rows and a "When the countdown reaches zero" section.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (39 tests passing, including new `completion.test.ts` and expanded `Home.test.tsx`/`Date.test.ts` coverage for every flag combination and precedence rule)
- [x] `pnpm build`
- [x] Manual verification via `vite preview` + headless Chromium against a built image: default freeze + message, `TIMER_DONE_COUNTUP`, `TIMER_DONE_HIDE_TIMER` + `TIMER_DONE_ANIMATION`, redirect winning over reload, invalid redirect URL falling back to reload with a console warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQBMGGBxhA1r9JFeaWG5tD)_