### PR TITLE
feat: add error boundary fallback for render errors (#148)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
+import ErrorBoundary from './components/ErrorBoundary';
 import Home from './scenes/Home';
 
 function App() {
   return (
     <div className="text-center">
-      <Home />
+      <ErrorBoundary>
+        <Home />
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+const headingClasses = 'mb-4 text-center text-3xl text-white sm:mb-6 sm:text-4xl lg:text-5xl';
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    const background = window.background;
+    const hasBackground = background && background.length > 0 && background !== '__BACKGROUND__';
+    const style = hasBackground ? { backgroundImage: `url('${background}')` } : undefined;
+
+    return (
+      <div
+        className="flex h-dvh items-center justify-center bg-cover bg-center bg-no-repeat"
+        style={style}
+      >
+        <div className="flex flex-col items-center px-4">
+          {window.title && window.title.length > 0 && (
+            <div className={headingClasses}>{window.title}</div>
+          )}
+          <div className={headingClasses}>Something went wrong</div>
+          <div className="text-center text-base text-white opacity-80">
+            The countdown ran into an unexpected error.
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ErrorBoundary from '../ErrorBoundary';
+
+function Throw(): never {
+  throw new Error('boom');
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.title = '';
+});
+
+describe('ErrorBoundary', () => {
+  it('renders the fallback UI when a child throws instead of crashing', () => {
+    render(
+      <ErrorBoundary>
+        <Throw />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('The countdown ran into an unexpected error.')).toBeInTheDocument();
+  });
+
+  it('logs the caught error via componentDidCatch', () => {
+    render(
+      <ErrorBoundary>
+        <Throw />
+      </ErrorBoundary>,
+    );
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('shows window.title in the fallback heading when set', () => {
+    window.title = 'Launch party';
+
+    render(
+      <ErrorBoundary>
+        <Throw />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Launch party')).toBeInTheDocument();
+  });
+
+  it('renders children unchanged when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div>All good</div>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('All good')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a React error boundary so a render error no longer white-screens the page. This is a kiosk-style always-on countdown display — it's meant to run unattended on a screen for hours or days, so a blank screen on error is much worse than for a typical web app. Now a render failure shows a friendly, on-brand fallback instead.

Closes item **1.4 (Error boundary)** of #148.

## Changes

- **`src/components/ErrorBoundary.tsx`** (new) — a class component (function components can't catch render errors) implementing `static getDerivedStateFromError` and `componentDidCatch`. `componentDidCatch` logs to `console.error` so kiosk operators have error visibility in logs.
- **Fallback UI** — mirrors `Home`'s styling for visual consistency (same Tailwind root classes and `headingClasses`): shows `window.title` when set, a generic "Something went wrong" message, and the configured background. The background inline style is guarded against an empty value and the unsubstituted `__BACKGROUND__` placeholder to avoid a broken request.
- **`src/App.tsx`** — wraps `<Home />` with `<ErrorBoundary>`.
- **`src/components/__tests__/ErrorBoundary.test.tsx`** (new) — renders a child that throws and asserts the fallback UI appears instead of a crash; also covers `componentDidCatch` logging, the `window.title` heading, and the transparent happy-path (children render unchanged when no error occurs).

## Scope note

`Home`'s module-scope `resolveTarget(window.target)` runs at import time, not during render, so the boundary intentionally does not catch that — item 1.4 targets render/lifecycle errors, and the invalid-target case is already handled by its own configuration-error panel (item 1.1).

## Verification

All CI gates pass locally: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (55 tests, incl. 4 new), `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142GmcsT8vYt6aZJYESeteM

---
_Generated by [Claude Code](https://claude.ai/code/session_0142GmcsT8vYt6aZJYESeteM)_