### PR TITLE
feat: respect prefers-reduced-motion in the slot-machine digit animation

### DIFF
--- a/src/scenes/Home/NumberDisplay/__tests__/NumberDisplay.test.tsx
+++ b/src/scenes/Home/NumberDisplay/__tests__/NumberDisplay.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import NumberDisplay from '../index';
+
+function mockMatchMedia(reduced: boolean): void {
+  const impl = (query: string): MediaQueryList => ({
+    matches: reduced && query === '(prefers-reduced-motion: reduce)',
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  });
+  vi.stubGlobal('matchMedia', vi.fn(impl));
+}
+
+function reel(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[style*="translateY"]');
+  if (el === null) {
+    throw new Error('reel element not found');
+  }
+  return el;
+}
+
+describe('NumberDisplay reduced-motion', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('skips the random intro roll and shows the real value immediately when reduced motion is preferred', () => {
+    mockMatchMedia(true);
+    // Would otherwise pick digit 5 as the random intro start.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    const { container } = render(<NumberDisplay value={7} />);
+
+    // Intro is skipped: the reel sits on the real value (7) from first paint, not the random 5.
+    expect(reel(container)).toHaveStyle({ transform: 'translateY(-700%)' });
+  });
+
+  it('starts on the random intro position when motion is allowed', () => {
+    mockMatchMedia(false);
+    // Pins the random intro start to digit 5.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    const { container } = render(<NumberDisplay value={7} />);
+
+    // Intro is active: the reel starts on the random 5 before rolling to the real value.
+    expect(reel(container)).toHaveStyle({ transform: 'translateY(-500%)' });
+  });
+});

--- a/src/scenes/Home/NumberDisplay/index.tsx
+++ b/src/scenes/Home/NumberDisplay/index.tsx
@@ -2,13 +2,24 @@ import { useState, useEffect } from 'react';
 
 const ten = Array.from(Array(10).keys());
 
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
 interface NumberDisplayProps {
   value: number;
 }
 
 // Slot-machine intro: each digit mounts on a random position, then rolls to its real value.
+// Skipped for users who prefer reduced motion — they see the real digit immediately.
 function NumberDisplay({ value: v }: NumberDisplayProps) {
-  const [intro, setIntro] = useState(() => Math.floor(Math.random() * 11));
+  const [intro, setIntro] = useState(() =>
+    prefersReducedMotion() ? -1 : Math.floor(Math.random() * 11),
+  );
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -24,7 +35,7 @@ function NumberDisplay({ value: v }: NumberDisplayProps) {
   return (
     <div aria-hidden="true" className="relative h-[1em] w-[0.7em] overflow-hidden">
       <div
-        className="relative h-full w-full transition-transform duration-[800ms]"
+        className="relative h-full w-full motion-safe:transition-transform motion-safe:duration-[800ms]"
         style={{ transform: `translateY(-${value * 100}%)` }}
       >
         {ten.map((t) => (


### PR DESCRIPTION
## Summary

Implements item **3.2** of the post-modernization roadmap (#148): reduced-motion support for the `NumberDisplay` slot-machine digit animation. Under `prefers-reduced-motion`, digits now **snap** directly to their value instead of rolling — both on load and on every countdown tick.

## Changes

- **Per-tick roll transition** — gated behind Tailwind's `motion-safe:` variant (`motion-safe:transition-transform motion-safe:duration-[800ms]`). Under reduced motion the `translateY` updates apply instantly. Verified in the built CSS that the transition is wrapped in `@media (prefers-reduced-motion: no-preference)`. This mirrors the existing `motion-safe:animate-done-pulse` usage elsewhere in `Home`.
- **Random intro roll** — guarded with `window.matchMedia('(prefers-reduced-motion: reduce)').matches` in the `useState` initializer, returning `-1` so the digit mounts on its real value with no roll. The `matchMedia` access is feature-detected (`typeof window`/`typeof window.matchMedia`) so it stays safe under SSR/jsdom.
- **Test** — new component test (`NumberDisplay/__tests__/NumberDisplay.test.tsx`) stubs `window.matchMedia` and pins `Math.random`, asserting the intro roll is skipped (reel sits on the real value) when reduced motion is preferred, and shown when it isn't.

Out of scope: the pre-existing `Math.random() * 11` range quirk is left untouched to keep the diff tight.

## Verification

- `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (53 passed), `pnpm build` — all pass.
- Manual: `pnpm dev -- --host`, then Chrome DevTools → Rendering → Emulate CSS media feature `prefers-reduced-motion: reduce` → digits snap instead of rolling.

Closes item 3.2 of #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWvvKMigNeMDLzgxHUyZxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWvvKMigNeMDLzgxHUyZxr)_