### PR TITLE
test: add Playwright E2E smoke test for the built app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,25 @@ jobs:
           TIMER_TARGET: '2030-01-01'
           TIMER_TITLE: 'CI'
 
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm build
+        env:
+          TIMER_BACKGROUND: ''
+          TIMER_TARGET: '2030-01-01T00:00:00Z'
+          TIMER_TITLE: 'Smoke Test'
+      - name: Run Playwright smoke test
+        run: pnpm exec playwright test
+
   secrets:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # production
 /build

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "export-issues": "node scripts/export-issues.js"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",
+    "@playwright/test": "^1.61.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@tailwindcss/vite": "^4.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Local sandboxes ship a pre-installed Chromium whose revision may not match the
+// browser @playwright/test would download. Point at it via this env var to reuse
+// it instead of fetching a new one; unset in CI, where `playwright install` runs.
+const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chromium'],
+        ...(chromiumExecutable ? { launchOptions: { executablePath: chromiumExecutable } } : {}),
+      },
+    },
+  ],
+  // Serve the built app (build/) exactly as it ships. The build itself — including
+  // variables.sh TIMER_* injection — is the caller's step (CI job / local `pnpm build`).
+  webServer: {
+    command: 'pnpm exec vite preview --port 4173 --strictPort',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.5
         version: 9.39.5
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@25.0.7(typescript@6.0.3))
@@ -383,6 +386,11 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1426,6 +1434,11 @@ packages:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2357,6 +2370,16 @@ packages:
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3444,6 +3467,10 @@ snapshots:
       '@octokit/openapi-types': 27.0.0
 
   '@oxc-project/types@0.139.0': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -4657,6 +4684,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5468,6 +5498,14 @@ snapshots:
     dependencies:
       find-up: 2.1.0
       load-json-file: 4.0.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, type Page } from '@playwright/test';
+
+interface BlockState {
+  label: string;
+  value: number;
+  valid: boolean;
+}
+
+// Reads the four countdown blocks from the *built* DOM. Digits are not text:
+// NumberDisplay renders a 0-9 stack and reveals the real digit via an inline
+// `transform: translateY(-<digit*100>%)`, so we decode that transform per digit.
+// A NaN countdown would yield an unparsable transform (or the wrong digit count),
+// which `valid` flags.
+async function readBlocks(page: Page): Promise<BlockState[]> {
+  return page.evaluate(() => {
+    const labelRe = /^(days?|hours?|minutes?|seconds?)$/;
+    // A block's full text is all-digits + label, so only the leaf label div
+    // matches the unit regex exactly.
+    const labels = Array.from(document.querySelectorAll<HTMLDivElement>('div')).filter(
+      (el) => el.childElementCount === 0 && labelRe.test(el.textContent.trim()),
+    );
+    return labels.map((label) => {
+      const block = label.parentElement;
+      const rollers = block
+        ? Array.from(block.querySelectorAll<HTMLDivElement>('div[style*="translateY"]'))
+        : [];
+      const digits = rollers.map((roller) => {
+        const match = /translateY\(-?(\d+(?:\.\d+)?)%\)/.exec(roller.style.transform);
+        return match ? Number(match[1]) / 100 : NaN;
+      });
+      const valid =
+        digits.length > 0 &&
+        digits.every((digit) => Number.isInteger(digit) && digit >= 0 && digit <= 9);
+      return {
+        label: label.textContent.trim(),
+        value: Number(digits.join('')),
+        valid,
+      };
+    });
+  });
+}
+
+test.describe('countdown smoke', () => {
+  test('renders configured countdown and ticks', async ({ page }) => {
+    await page.goto('/');
+
+    // The runtime-configured title (from TIMER_TITLE via variables.sh) must reach
+    // both the document title and the on-screen heading.
+    const configuredTitle = await page.evaluate(() => window.title);
+    expect(configuredTitle.length).toBeGreaterThan(0);
+    await expect(page).toHaveTitle(configuredTitle);
+    await expect(page.getByText(configuredTitle, { exact: true })).toBeVisible();
+
+    // Wait out the slot-machine intro so decoded digits reflect real values.
+    await expect
+      .poll(async () => (await readBlocks(page)).every((block) => block.valid))
+      .toBe(true);
+
+    const blocks = await readBlocks(page);
+    expect(blocks).toHaveLength(4);
+    // Documented invariant: blocks render in day -> hour -> minute -> second order.
+    expect(blocks[0]?.label).toMatch(/^days?$/);
+    expect(blocks[1]?.label).toMatch(/^hours?$/);
+    expect(blocks[2]?.label).toMatch(/^minutes?$/);
+    expect(blocks[3]?.label).toMatch(/^seconds?$/);
+
+    for (const block of blocks) {
+      expect(block.valid).toBe(true);
+      expect(Number.isFinite(block.value)).toBe(true);
+    }
+
+    // Prove the 1 s interval actually ticks (not a static render): the seconds
+    // value must change within ~1.1 s.
+    const before = await readBlocks(page);
+    await page.waitForTimeout(1100);
+    const after = await readBlocks(page);
+    expect(after[3]?.value).not.toBe(before[3]?.value);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "isolatedModules": true,
     "types": ["vite/client", "node"]
   },
-  "include": ["src", "__tests__", "vite.config.ts"]
+  "include": ["src", "__tests__", "tests", "vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
Closes item **2.2** of the post-modernization roadmap (#148).

## What & why

The app's whole point is a single prebuilt bundle configured at **runtime** via `variables.sh` placeholder substitution into `window.*` globals. Unit/component tests mock those globals, so nothing currently exercises the *built* app end-to-end. This adds a Playwright smoke test that serves `build/` (as it actually ships) and verifies the app renders a live, ticking countdown — catching whole-app regressions (broken `variables-final.js` injection, asset paths under `base: './'`, the render pipeline, the 1 s interval) that no existing test would.

Test/CI infrastructure only — no `src/` behavior changes.

## What the smoke test asserts

`tests/smoke.spec.ts` serves `build/` via `vite preview` and checks:

- The configured title (from `TIMER_TITLE`) reaches both `document.title` and the on-screen heading.
- Four labeled blocks render in **day → hour → minute → second** order (the documented insertion-order invariant), matching `days?`/`hours?`/… since `Block` labels are singular for 0/1.
- Each block's digits decode to **valid, non-NaN** values. Digits aren't text — `NumberDisplay` reveals them via `transform: translateY(-<digit*100>%)`, so the test decodes that transform and validates each digit is an integer 0–9.
- After ~1.1 s the **seconds value changes**, proving the interval ticks rather than a static render.

## Changes

- `pnpm add -D @playwright/test`; `playwright.config.ts` scoped to **Chromium only** (smoke, not cross-browser). Honors `PLAYWRIGHT_CHROMIUM_EXECUTABLE` so a sandbox's pre-installed browser can be reused instead of downloading one; unset in CI.
- New **`e2e`** job in `.github/workflows/ci.yml`: `playwright install --with-deps chromium` → `pnpm build` (fixed `TIMER_TARGET`) → `pnpm exec playwright test`. Separate from the existing lint/typecheck/unit/audit/gitleaks jobs, reusing the same pinned action SHAs.
- `tests/` + `playwright.config.ts` added to `tsconfig.json` `include` so strict typecheck and lint cover them; `playwright-report/` and `test-results/` gitignored; `test:e2e` convenience script added.

## Verification

Locally green: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (Vitest, unchanged — does not pick up the `.spec.ts`), `pnpm build`, and the Playwright test — run multiple times against both a near-future and a far-future (multi-digit day) target with no flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQuKpsQ9B7ATb5HHSDGoJV)_