### PR TITLE
chore: enforce coverage floor and document the convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
           node --input-type=module <<'EOF'
           import { readFileSync, appendFileSync } from 'node:fs';
           const out = process.env.GITHUB_STEP_SUMMARY;
-          const TARGET = 60; // soft line-coverage target; not a hard gate — ratchet later
+          // Coverage floors are enforced by Vitest's coverage.thresholds (see vite.config.ts); the
+          // test:coverage step above fails the job on a regression. This step only renders the table.
           let data;
           try {
             data = JSON.parse(readFileSync('coverage/coverage-summary.json', 'utf8'));
@@ -51,13 +52,10 @@ jobs:
             row('Functions', t.functions),
             row('Branches', t.branches),
             '',
-            `_Soft target: ${TARGET}% lines — reported, not enforced (ratchet later)._`,
+            '_Enforced floor: lines/statements 90%, functions/branches 85% (see vite.config.ts). Ratchet up over time._',
             '',
           ].join('\n');
           if (out) appendFileSync(out, table);
-          if (t.lines.pct < TARGET) {
-            console.log(`::warning::Line coverage ${t.lines.pct}% is below the soft target of ${TARGET}%.`);
-          }
           EOF
       - run: pnpm build
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,17 +53,23 @@ The primary deployment target is a single Docker container configured at **runti
 ## CI gates (all must pass)
 
 `.github/workflows/ci.yml` on push/PR to master: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`,
-`pnpm test` (Vitest), `pnpm build`, `pnpm audit --audit-level high` (high/critical CVEs fail CI), and
-gitleaks secret scanning over full git history (any committed secret fails CI).
+`pnpm test:coverage` (Vitest + v8 coverage — **an enforced coverage floor fails CI on regression**; see Testing),
+`pnpm build`, a Playwright E2E smoke test (`e2e` job), `pnpm audit --audit-level high` (high/critical CVEs fail CI),
+and gitleaks secret scanning over full git history (any committed secret fails CI).
 CodeQL (`codeql.yml`) scans JS/TS + Actions. Dependabot opens weekly bump PRs (npm, docker, github-actions).
 Published releases trigger `docker-publish.yml`, pushing `yiddy/simple-countdown:<semver>` and `:latest`.
 
 ## Testing
 
 - Vitest; unit tests co-located as `__tests__/<Subject>.test.ts` next to the module (see `src/service/__tests__/Date.test.ts`).
-- Test behavior, not implementation. Run `pnpm test` before reporting any task complete.
+- Test behavior, not implementation. Run `pnpm test` (or `pnpm test:coverage`) before reporting any task complete.
 - Tests ship with the change: any feature or fix PR includes its unit/component tests in the same
   commit — don't defer coverage to a follow-up PR.
+- **Coverage is enforced.** `pnpm test:coverage` runs v8 coverage and CI fails if it drops below the
+  floor in `vite.config.ts`'s `test.coverage.thresholds` (currently lines/statements 90%, functions/branches 85%;
+  actual is higher). New code must keep coverage at or above the floor — the fix is to add tests, never
+  to lower a threshold. **Ratchet the floor UP** toward the actual as coverage climbs; the CI job summary
+  prints the current coverage table each run.
 - Component tests use Testing Library + jsdom (`test.environment: 'jsdom'` in `vite.config.ts`;
   jest-dom matchers loaded via `src/test/setup.ts`).
 - `describe()` in `src/service/date.ts` must keep key insertion order day → hour → minute → second; `Home` renders blocks from `Object.entries` order.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,9 +19,16 @@ export default defineConfig({
       reportsDirectory: './coverage',
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/**/__tests__/**', 'src/test/**', 'src/**/*.d.ts', 'src/index.tsx'],
-      // Soft target: 60% line coverage. Intentionally NOT enforced here — Vitest thresholds are a
-      // hard gate with no warn-only mode, so CI emits a non-failing warning instead (see ci.yml).
-      // Ratchet up later by adding `thresholds: { lines: N }` once coverage is comfortably above it.
+      // Enforced coverage floor: `pnpm test:coverage` (and therefore CI) fails if coverage drops
+      // below these. Set below the current baseline (lines/statements ~97%, functions/branches ~90-96%)
+      // with headroom so a normal PR that ships its own tests won't trip it, while a real regression
+      // will. Ratchet these numbers UP over time as coverage climbs — never down to make a red CI pass.
+      thresholds: {
+        lines: 90,
+        statements: 90,
+        functions: 85,
+        branches: 85,
+      },
     },
   },
 });


### PR DESCRIPTION
Follow-up to #157 (coverage reporting). Turns the soft coverage target into an **enforced floor** so future development can't silently regress coverage, and documents the convention in `CLAUDE.md` so it persists.

## What changed
- **`vite.config.ts`** — added `test.coverage.thresholds`: `lines: 90`, `statements: 90`, `functions: 85`, `branches: 85`. These sit below the current baseline (lines/statements ~97%, functions ~91%, branches ~96%) with headroom, so a normal PR that ships its own tests won't trip them, while a real regression will. `pnpm test:coverage` — and therefore the CI `checks` job — now **fails** when coverage drops below the floor.
- **`.github/workflows/ci.yml`** — the coverage floor is now enforced by Vitest itself, so the old non-failing `<60%` `::warning::` in the job-summary step is removed (it was both dead and inconsistent with the new floor). The step still renders the coverage table to the job summary each run.
- **`CLAUDE.md`** — CI gates + Testing sections updated: the test gate is `pnpm test:coverage` with an enforced floor, new code must keep coverage at/above it (add tests, don't lower thresholds), and the floor should be **ratcheted up** over time. Also corrected the gate list to mention the coverage step and the Playwright `e2e` job that landed in #158.

## Why these numbers
The earlier "soft, ratchet later" choice (#157) was step one — make coverage visible. This is the ratchet: lock in a floor near the baseline. Numbers are deliberately a few points under actuals because branch/function coverage is volatile in a small codebase; the intent is to catch regressions, not to make every small PR fight the threshold. Bump them upward as coverage climbs.

## Verification
- `pnpm test:coverage` passes with thresholds enforced (exit 0; lines 97.32% / statements 97.39% / functions 90.62% / branches 96.15%).
- `pnpm lint`, `pnpm format:check`, `pnpm typecheck` all clean; `ci.yml` parses (4 jobs).

> Note: CI on this PR actually exercises the enforced threshold and the updated summary step, so watch its run for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mK9G8LddXUSnySYVNFMXa

---
_Generated by [Claude Code](https://claude.ai/code/session_019mK9G8LddXUSnySYVNFMXa)_