### PR TITLE
test: cover runtime-config scenarios with Playwright E2E

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--
+  Conventional-commit PR titles (feat:, fix:, chore:, test:, docs: …) — semantic-release
+  derives the version bump from merged commit messages. See CLAUDE.md.
+-->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Testing
+
+- [ ] Unit/component tests added or updated (`pnpm test`)
+- [ ] Runtime-config changes (`TIMER_*` vars, `window.*` globals, `variables.sh`, target/completion
+      behavior) ship with a Playwright E2E scenario (`tests/scenarios.ts` + `tests/<name>.spec.ts`) — or
+      N/A for this change
+- [ ] `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build` pass locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm build
-        env:
-          TIMER_BACKGROUND: ''
-          TIMER_TARGET: '2030-01-01T00:00:00Z'
-          TIMER_TITLE: 'Smoke Test'
-      - name: Run Playwright smoke test
-        run: pnpm exec playwright test
+      # test:e2e builds every scenario variant (build-e2e/*) from its own TIMER_*
+      # config, then runs the Playwright suite against the served builds.
+      - name: Run Playwright E2E scenarios
+        run: pnpm test:e2e
 
   secrets:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 # production
 /build
+# per-scenario E2E builds (see tests/scenarios.ts)
+/build-e2e
 
 # misc
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 build/
+build-e2e/
 CHANGELOG.md
 coverage/
 pnpm-lock.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,9 @@ The primary deployment target is a single Docker container configured at **runti
 
 `.github/workflows/ci.yml` on push/PR to master: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`,
 `pnpm test:coverage` (Vitest + v8 coverage — **an enforced coverage floor fails CI on regression**; see Testing),
-`pnpm build`, a Playwright E2E smoke test (`e2e` job), `pnpm audit --audit-level high` (high/critical CVEs fail CI),
-and gitleaks secret scanning over full git history (any committed secret fails CI).
+`pnpm build`, the Playwright E2E scenarios (`e2e` job runs `pnpm test:e2e`; see Testing),
+`pnpm audit --audit-level high` (high/critical CVEs fail CI), and gitleaks secret scanning over full git
+history (any committed secret fails CI).
 CodeQL (`codeql.yml`) scans JS/TS + Actions. Dependabot opens weekly bump PRs (npm, docker, github-actions).
 Published releases trigger `docker-publish.yml`, pushing `yiddy/simple-countdown:<semver>` and `:latest`.
 
@@ -73,6 +74,23 @@ Published releases trigger `docker-publish.yml`, pushing `yiddy/simple-countdown
 - Component tests use Testing Library + jsdom (`test.environment: 'jsdom'` in `vite.config.ts`;
   jest-dom matchers loaded via `src/test/setup.ts`).
 - `describe()` in `src/service/date.ts` must keep key insertion order day → hour → minute → second; `Home` renders blocks from `Object.entries` order.
+
+### Playwright E2E (`tests/*.spec.ts`)
+
+- E2E is the **only** layer that exercises the built app end-to-end — the `variables.sh` → `window.*`
+  runtime-config path that unit/component tests mock away. Each scenario is a **separate build** because
+  `TIMER_*` config is baked into `variables-final.js` at build time.
+- Architecture: `tests/scenarios.ts` is the single source of truth (name, port, `outDir`, `TIMER_*` env);
+  `tests/build-e2e.ts` (run before Playwright by `pnpm test:e2e`) builds each variant into `build-e2e/<name>`;
+  `playwright.config.ts` serves each on its own port; each `tests/<name>.spec.ts` targets its scenario via
+  `test.use({ baseURL })`. Chromium-only. (Builds run before Playwright, not in a setup hook, because the web
+  servers start before any hook.)
+- **Any change to the runtime-config surface ships with an E2E scenario in the same PR** — new/changed
+  `TIMER_*` vars, `window.*` globals, `variables.sh` substitution, or target/completion behavior. Adding a
+  scenario = add an entry to `tests/scenarios.ts` + a `tests/<name>.spec.ts`; the build variant and preview
+  server follow automatically. (Same "tests ship with the change" rule as unit tests, applied to the built app.)
+- Run locally with `pnpm test:e2e` (it builds the variants, then Playwright serves them). In a sandbox
+  with a pre-installed Chromium, set `PLAYWRIGHT_CHROMIUM_EXECUTABLE` to reuse it instead of downloading one.
 
 ## Docker
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ import globals from 'globals';
 
 export default tseslint.config(
   {
-    ignores: ['build/', 'node_modules/', 'public/variables-final.js', 'coverage/'],
+    ignores: ['build/', 'build-e2e/', 'node_modules/', 'public/variables-final.js', 'coverage/'],
   },
   js.configs.recommended,
   ...tseslint.configs.strictTypeChecked,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "test:e2e": "playwright test",
+    "build:e2e": "node tests/build-e2e.ts",
+    "test:e2e": "pnpm build:e2e && playwright test",
     "export-issues": "node scripts/export-issues.js"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { scenarios } from './tests/scenarios';
 
 // Local sandboxes ship a pre-installed Chromium whose revision may not match the
 // browser @playwright/test would download. Point at it via this env var to reuse
@@ -12,7 +13,8 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:4173',
+    // Default target is the "valid" build; scenario specs override baseURL per file.
+    baseURL: `http://localhost:${scenarios[0]?.port ?? 4173}`,
     trace: 'on-first-retry',
   },
   projects: [
@@ -24,12 +26,13 @@ export default defineConfig({
       },
     },
   ],
-  // Serve the built app (build/) exactly as it ships. The build itself — including
-  // variables.sh TIMER_* injection — is the caller's step (CI job / local `pnpm build`).
-  webServer: {
-    command: 'pnpm exec vite preview --port 4173 --strictPort',
-    url: 'http://localhost:4173',
+  // One preview server per scenario, each serving its own pre-built config.
+  // The build-e2e/* dirs are produced by `node tests/build-e2e.ts` (run before
+  // Playwright via `pnpm test:e2e`), since web servers start before any setup hook.
+  webServer: scenarios.map((scenario) => ({
+    command: `pnpm exec vite preview --outDir ${scenario.outDir} --port ${scenario.port} --strictPort`,
+    url: `http://localhost:${scenario.port}`,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
-  },
+  })),
 });

--- a/tests/build-e2e.ts
+++ b/tests/build-e2e.ts
@@ -1,0 +1,19 @@
+import { execFileSync } from 'node:child_process';
+import { scenarios } from './scenarios.ts';
+
+// Builds every E2E scenario before Playwright starts (run via `pnpm test:e2e`).
+// Each build runs the real variables.sh -> variables-final.js substitution — the
+// runtime-config path unit tests mock away — then emits into the scenario's own
+// dir so playwright.config.ts can serve them side by side. Sequential on purpose:
+// variables.sh writes the shared public/variables-final.js, so parallel builds
+// would race. Runs as a standalone script (Node strips the types) rather than a
+// Playwright globalSetup, which starts after the web servers that need these dirs.
+for (const scenario of scenarios) {
+  const env = { ...process.env, ...scenario.env };
+  console.log(`[e2e] building scenario "${scenario.name}" -> ${scenario.outDir}`);
+  execFileSync('bash', ['variables.sh', 'public'], { stdio: 'inherit', env });
+  execFileSync('pnpm', ['exec', 'vite', 'build', '--outDir', scenario.outDir], {
+    stdio: 'inherit',
+    env,
+  });
+}

--- a/tests/countup.spec.ts
+++ b/tests/countup.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { scenarioUrl } from './scenarios';
+import { readBlocks } from './helpers';
+
+// Built with a past TIMER_TARGET and TIMER_DONE_COUNTUP=true. There is no done
+// state in countup mode: the timer keeps ticking upward and no message shows.
+test.use({ baseURL: scenarioUrl('countup') });
+
+test.describe('countdown completion (countup)', () => {
+  test('keeps ticking past zero with no done message', async ({ page }) => {
+    await page.goto('/');
+
+    // Title heading stays (no done takeover); the default done message never shows.
+    await expect(page.getByText('Smoke Test', { exact: true })).toBeVisible();
+    await expect(page.getByText('The wait is over!')).toHaveCount(0);
+
+    await expect
+      .poll(async () => (await readBlocks(page)).every((block) => block.valid))
+      .toBe(true);
+
+    const blocks = await readBlocks(page);
+    expect(blocks).toHaveLength(4);
+
+    // Still running: the seconds value keeps changing past the target.
+    const before = await readBlocks(page);
+    await page.waitForTimeout(1100);
+    const after = await readBlocks(page);
+    expect(after[3]?.value).not.toBe(before[3]?.value);
+  });
+});

--- a/tests/done.spec.ts
+++ b/tests/done.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { scenarioUrl } from './scenarios';
+import { readBlocks } from './helpers';
+
+// Built with a past TIMER_TARGET and a custom TIMER_DONE_MESSAGE. Home freezes
+// the timer at 00:00:00:00 and shows the message (issue #154, default freeze mode).
+test.use({ baseURL: scenarioUrl('done') });
+
+test.describe('countdown completion (freeze)', () => {
+  test('shows the done message and freezes at zero', async ({ page }) => {
+    await page.goto('/');
+
+    // The configured completion message replaces the title heading.
+    await expect(page.getByText('All finished!')).toBeVisible();
+
+    await expect
+      .poll(async () => (await readBlocks(page)).every((block) => block.valid))
+      .toBe(true);
+
+    const blocks = await readBlocks(page);
+    expect(blocks).toHaveLength(4);
+    expect(blocks.every((block) => block.value === 0)).toBe(true);
+
+    // Frozen: the seconds value must NOT change (the interval is stopped once done).
+    const secondsBefore = blocks[3]?.value;
+    await page.waitForTimeout(1100);
+    const after = await readBlocks(page);
+    expect(after[3]?.value).toBe(secondsBefore);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,41 @@
+import { type Page } from '@playwright/test';
+
+export interface BlockState {
+  label: string;
+  value: number;
+  valid: boolean;
+}
+
+// Reads the four countdown blocks from the *built* DOM. Digits are not text:
+// NumberDisplay renders a 0-9 stack and reveals the real digit via an inline
+// `transform: translateY(-<digit*100>%)`, so we decode that transform per digit.
+// A NaN countdown would yield an unparsable transform (or the wrong digit count),
+// which `valid` flags.
+export async function readBlocks(page: Page): Promise<BlockState[]> {
+  return page.evaluate(() => {
+    const labelRe = /^(days?|hours?|minutes?|seconds?)$/;
+    // A block's full text is all-digits + label, so only the leaf label div
+    // matches the unit regex exactly.
+    const labels = Array.from(document.querySelectorAll<HTMLDivElement>('div')).filter(
+      (el) => el.childElementCount === 0 && labelRe.test(el.textContent.trim()),
+    );
+    return labels.map((label) => {
+      const block = label.parentElement;
+      const rollers = block
+        ? Array.from(block.querySelectorAll<HTMLDivElement>('div[style*="translateY"]'))
+        : [];
+      const digits = rollers.map((roller) => {
+        const match = /translateY\(-?(\d+(?:\.\d+)?)%\)/.exec(roller.style.transform);
+        return match ? Number(match[1]) / 100 : NaN;
+      });
+      const valid =
+        digits.length > 0 &&
+        digits.every((digit) => Number.isInteger(digit) && digit >= 0 && digit <= 9);
+      return {
+        label: label.textContent.trim(),
+        value: Number(digits.join('')),
+        valid,
+      };
+    });
+  });
+}

--- a/tests/invalid.spec.ts
+++ b/tests/invalid.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import { scenarioUrl } from './scenarios';
+
+// Built with an unparsable TIMER_TARGET. resolveTarget() returns null, so Home
+// renders the configuration-error panel instead of a NaN countdown (issue #149).
+test.use({ baseURL: scenarioUrl('invalid') });
+
+test.describe('countdown with invalid target', () => {
+  test('renders the configuration-error panel, not a countdown', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByText('No valid countdown target configured')).toBeVisible();
+    await expect(page.getByText(/Set TIMER_TARGET to an ISO 8601 date/)).toBeVisible();
+
+    // No countdown blocks render in the error state.
+    await expect(page.getByText(/^(days?|hours?|minutes?|seconds?)$/)).toHaveCount(0);
+  });
+});

--- a/tests/redirect.spec.ts
+++ b/tests/redirect.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { scenarioUrl } from './scenarios';
+
+// Built with a past TIMER_TARGET and a TIMER_DONE_REDIRECT_URL (pointing at the
+// "valid" server) with a short delay. On completion Home navigates there via
+// window.location.assign (issues #16/#17, covered by #154's redirect follow-up).
+test.use({ baseURL: scenarioUrl('redirect') });
+
+test.describe('countdown completion (redirect)', () => {
+  test('navigates to the configured URL after the delay', async ({ page }) => {
+    await page.goto('/');
+
+    // The done message shows briefly, then the follow-up redirect fires.
+    await expect(page.getByText('The wait is over!')).toBeVisible();
+
+    // The behavior under test is the completion -> redirect navigation. 'commit'
+    // resolves as soon as that navigation lands, without waiting on the
+    // destination's full load lifecycle (its render is covered by smoke.spec.ts,
+    // and the app's Google-Fonts request is reset by the sandbox proxy, which can
+    // delay 'load' under parallel load).
+    await page.waitForURL(`${scenarioUrl('valid')}/`, { waitUntil: 'commit', timeout: 15_000 });
+    expect(page.url()).toBe(`${scenarioUrl('valid')}/`);
+  });
+});

--- a/tests/reduced-motion.spec.ts
+++ b/tests/reduced-motion.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { scenarioUrl } from './scenarios';
+import { readBlocks } from './helpers';
+
+// Reuses the "valid" build but emulates prefers-reduced-motion: reduce. The
+// slot-machine roll is gated behind Tailwind's motion-safe: variant (issue #156),
+// so under reduced motion the digit rollers carry no CSS transition.
+test.use({ baseURL: scenarioUrl('valid'), contextOptions: { reducedMotion: 'reduce' } });
+
+test.describe('reduced motion', () => {
+  test('digit rollers have no transition when motion is reduced', async ({ page }) => {
+    await page.goto('/');
+
+    await expect
+      .poll(async () => (await readBlocks(page)).every((block) => block.valid))
+      .toBe(true);
+
+    const roller = page.locator('div[style*="translateY"]').first();
+    const transitionDuration = await roller.evaluate(
+      (el) => getComputedStyle(el).transitionDuration,
+    );
+    expect(transitionDuration).toBe('0s');
+  });
+});

--- a/tests/scenarios.ts
+++ b/tests/scenarios.ts
@@ -1,0 +1,83 @@
+// Single source of truth for the E2E scenarios. Each scenario is a distinct
+// *build* of the app: the countdown is configured at build time by variables.sh
+// substituting TIMER_* env into variables-final.js, so a config-dependent
+// behavior (invalid target, done state, countup, redirect) can only be exercised
+// end-to-end by building a variant and serving it. global-setup.ts builds each
+// into its own dir; playwright.config.ts serves each on its own port.
+
+export interface Scenario {
+  /** Stable id used for the output dir and referenced by the matching spec. */
+  name: string;
+  /** Dedicated preview port so scenarios can run in parallel. */
+  port: number;
+  /** vite build --outDir target (relative to repo root). */
+  outDir: string;
+  /** TIMER_* env baked into this build via variables.sh. */
+  env: Record<string, string>;
+}
+
+// A comfortably-future target so the "valid" build is always mid-countdown (the
+// margin must outlast the whole suite, incl. builds + CI browser install), and a
+// firmly-past one so the "done"/countup/redirect builds are immediately complete.
+const FUTURE_TARGET = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+const PAST_TARGET = '2000-01-01T00:00:00Z';
+const TITLE = 'Smoke Test';
+
+export const scenarios: Scenario[] = [
+  {
+    name: 'valid',
+    port: 4173,
+    outDir: 'build-e2e/valid',
+    env: { TIMER_BACKGROUND: '', TIMER_TARGET: FUTURE_TARGET, TIMER_TITLE: TITLE },
+  },
+  {
+    name: 'invalid',
+    port: 4174,
+    outDir: 'build-e2e/invalid',
+    env: { TIMER_BACKGROUND: '', TIMER_TARGET: 'not-a-real-date', TIMER_TITLE: TITLE },
+  },
+  {
+    name: 'done',
+    port: 4175,
+    outDir: 'build-e2e/done',
+    env: {
+      TIMER_BACKGROUND: '',
+      TIMER_TARGET: PAST_TARGET,
+      TIMER_TITLE: TITLE,
+      TIMER_DONE_MESSAGE: 'All finished!',
+    },
+  },
+  {
+    name: 'countup',
+    port: 4176,
+    outDir: 'build-e2e/countup',
+    env: {
+      TIMER_BACKGROUND: '',
+      TIMER_TARGET: PAST_TARGET,
+      TIMER_TITLE: TITLE,
+      TIMER_DONE_COUNTUP: 'true',
+    },
+  },
+  {
+    name: 'redirect',
+    port: 4177,
+    outDir: 'build-e2e/redirect',
+    env: {
+      TIMER_BACKGROUND: '',
+      TIMER_TARGET: PAST_TARGET,
+      TIMER_TITLE: TITLE,
+      // Redirect to the "valid" server so the follow-up navigation lands on a
+      // real page (no external network, no redirect loop).
+      TIMER_DONE_REDIRECT_URL: 'http://localhost:4173/',
+      TIMER_DONE_DELAY_MS: '300',
+    },
+  },
+];
+
+export function scenarioUrl(name: string): string {
+  const scenario = scenarios.find((candidate) => candidate.name === name);
+  if (!scenario) {
+    throw new Error(`Unknown E2E scenario: ${name}`);
+  }
+  return `http://localhost:${scenario.port}`;
+}

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,46 +1,8 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import { readBlocks } from './helpers';
 
-interface BlockState {
-  label: string;
-  value: number;
-  valid: boolean;
-}
-
-// Reads the four countdown blocks from the *built* DOM. Digits are not text:
-// NumberDisplay renders a 0-9 stack and reveals the real digit via an inline
-// `transform: translateY(-<digit*100>%)`, so we decode that transform per digit.
-// A NaN countdown would yield an unparsable transform (or the wrong digit count),
-// which `valid` flags.
-async function readBlocks(page: Page): Promise<BlockState[]> {
-  return page.evaluate(() => {
-    const labelRe = /^(days?|hours?|minutes?|seconds?)$/;
-    // A block's full text is all-digits + label, so only the leaf label div
-    // matches the unit regex exactly.
-    const labels = Array.from(document.querySelectorAll<HTMLDivElement>('div')).filter(
-      (el) => el.childElementCount === 0 && labelRe.test(el.textContent.trim()),
-    );
-    return labels.map((label) => {
-      const block = label.parentElement;
-      const rollers = block
-        ? Array.from(block.querySelectorAll<HTMLDivElement>('div[style*="translateY"]'))
-        : [];
-      const digits = rollers.map((roller) => {
-        const match = /translateY\(-?(\d+(?:\.\d+)?)%\)/.exec(roller.style.transform);
-        return match ? Number(match[1]) / 100 : NaN;
-      });
-      const valid =
-        digits.length > 0 &&
-        digits.every((digit) => Number.isInteger(digit) && digit >= 0 && digit <= 9);
-      return {
-        label: label.textContent.trim(),
-        value: Number(digits.join('')),
-        valid,
-      };
-    });
-  });
-}
-
-test.describe('countdown smoke', () => {
+// Uses the default baseURL from playwright.config.ts (the "valid" build).
+test.describe('countdown smoke (valid target)', () => {
   test('renders configured countdown and ticks', async ({ page }) => {
     await page.goto('/');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "types": ["vite/client", "node"]


### PR DESCRIPTION
## Summary

The smoke test (#158) only exercised the happy-path countdown. Several features merged since then live on the `variables.sh` → `window.*` **runtime-config** path that unit/component tests mock away and only E2E can reach. This expands the E2E suite to cover them, and adds a guardrail so future runtime-config work ships with E2E coverage. Advances issue #148 (item 2.2).

No `src/` behavior changes — test/CI/docs only.

## Changes

**Per-scenario E2E architecture.** Each scenario is a *separate build* (config is baked into `variables-final.js` at build time):
- `tests/scenarios.ts` — single source of truth (name, port, `outDir`, `TIMER_*` env).
- `tests/build-e2e.ts` — builds every variant into `build-e2e/*` before Playwright runs (a pre-step via `pnpm test:e2e`, **not** a setup hook, since Playwright starts the web servers before any hook — the reason `globalSetup` didn't work).
- `playwright.config.ts` — one `vite preview` server per scenario; each spec targets its scenario via `test.use({ baseURL })`.
- `tests/helpers.ts` — shared `readBlocks` (decodes the `translateY` digit transforms), extracted from the smoke spec.

**Scenarios** (alongside the existing valid/smoke case):
- `invalid` — unparsable `TIMER_TARGET` renders the config-error panel, no timer (#149).
- `done` — past target freezes at `00:00:00:00` and shows `TIMER_DONE_MESSAGE` (#154).
- `countup` — `TIMER_DONE_COUNTUP` keeps ticking past zero, no done message (#154).
- `redirect` — `TIMER_DONE_REDIRECT_URL` navigates on completion (#154; closes out #16/#17).
- `reduced-motion` — emulated `prefers-reduced-motion` drops the roll transition (#156).

**Enforcement for future work:**
- CLAUDE.md Testing section: changes to the runtime-config surface (`TIMER_*` / `window.*` / `variables.sh` / target-completion behavior) ship with an E2E scenario in the same PR.
- New `.github/pull_request_template.md` with an E2E-coverage checklist item.

**Plumbing:** `e2e` CI job now runs `pnpm test:e2e`; `build-e2e/` is git/eslint/prettier-ignored; `tsconfig` gains `allowImportingTsExtensions` so `build-e2e.ts` can reuse `scenarios.ts` when run by Node.

## Related issues

Advances #148 (item 2.2). Exercises #149, #154 (#16/#17), #156.

## Testing

- [ ] Unit/component tests added or updated (`pnpm test`) — N/A (no `src/` change); unit suite unaffected (57 passing).
- [x] Runtime-config changes ship with a Playwright E2E scenario — this PR *is* that coverage (5 new scenarios).
- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build` pass locally; `pnpm test:coverage` at 97% (above #159's floor); `pnpm test:e2e` — 6/6 green across two runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQuKpsQ9B7ATb5HHSDGoJV)_