### PR TITLE
fix: pass untrusted event data via env: in slack-notify workflow

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -60,31 +60,33 @@ jobs:
 
       - name: Format event details as one line
         id: event_info
+        env:
+          EVENT: ${{ github.event_name }}
+          BRANCH: ${{ github.ref_name }}
+          COMMITS_JSON: ${{ toJson(github.event.commits) }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_ACTION: ${{ github.event.action }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_ACTION: ${{ github.event.action }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          WORKFLOW_NAME: ${{ github.event.workflow.name }}
         run: |
-          EVENT="${{ github.event_name }}"
           DETAILS=""
           case "$EVENT" in
             push)
-              BRANCH="${{ github.ref_name }}"
-              COMMITS=$(echo '${{ toJson(github.event.commits) }}' | jq -r '.[].message')
+              COMMITS=$(echo "$COMMITS_JSON" | jq -r '.[].message')
               COMMITS=$(echo "$COMMITS" | tr '\n' ' | ' | sed 's/| $//; s/"/\\"/g')
               DETAILS="Commits pushed to \`$BRANCH\`: $COMMITS"
               ;;
             pull_request)
-              TITLE="${{ github.event.pull_request.title }}"
-              ACTION="${{ github.event.action }}"
-              BRANCH="${{ github.event.pull_request.head.ref }}"
-              DETAILS="Pull Request *$ACTION*: \`$TITLE\` (branch: \`$BRANCH\`)"
+              DETAILS="Pull Request *$PR_ACTION*: \`$PR_TITLE\` (branch: \`$PR_BRANCH\`)"
               ;;
             issues)
-              TITLE="${{ github.event.issue.title }}"
-              ACTION="${{ github.event.action }}"
-              NUMBER="${{ github.event.issue.number }}"
-              DETAILS="Issue *$ACTION*: \`#$NUMBER - $TITLE\`"
+              DETAILS="Issue *$ISSUE_ACTION*: \`#$ISSUE_NUMBER - $ISSUE_TITLE\`"
               ;;
             workflow_run)
-              NAME="${{ github.event.workflow.name }}"
-              DETAILS="Workflow run triggered by *$NAME*"
+              DETAILS="Workflow run triggered by *$WORKFLOW_NAME*"
               ;;
             *)
               DETAILS="$EVENT event triggered"


### PR DESCRIPTION
## Summary

`.github/workflows/slack-notify.yml`'s "Format event details as one line" step interpolated `${{ toJson(github.event.commits) }}`, `${{ github.event.pull_request.title }}`, and `${{ github.event.issue.title }}` directly into `run:` shell text via `${{ }}` substitution. GitHub Actions substitutes these expressions into the script *before* the shell parses it, so untrusted text becomes literal shell source.

This already broke CI outright: run [29716335622](https://github.com/yiddytlq/simple-countdown/actions/runs/29716335622) failed on push to `master` because the squash-merge commit message `test: add Playwright E2E smoke test for the built app (#158)` contained an unmatched `(`. Beyond the reliability bug, this is the documented GitHub Actions [script-injection anti-pattern](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) — untrusted event text (commit messages, PR/issue titles) landing in shell source, in a workflow that has `secrets.SLACK_WEBHOOK_URL` access.

## Fix

Moved every free-text `github.event.*` field used by that step (`toJson(github.event.commits)`, PR title, PR head ref, issue title, workflow name — plus the event name/branch for consistency) into a step-level `env:` block, referenced as shell variables (`$VAR`) instead of `${{ }}` interpolation inside the script body. `env:` values are passed as real environment variables, not text-substituted into the script source, so shell metacharacters can no longer break or inject into the script.

Behavior is unchanged: same `case` branches, same `GITHUB_OUTPUT` line format (`details=...`), same commit-message flattening pipeline (`jq -r '.[].message'` → `tr` → `sed`).

### Other steps checked, no change needed

- **"Determine if workflow should notify"** and **"Determine status emoji and color"** only use `github.actor`, `github.event_name`, `github.event.workflow_run.name`/`.conclusion`, `job.status` — enum values and actor/workflow names, not attacker-controlled free text.
- **"Send Slack Notification"**'s `payload:` block interpolates values into a `with:` input (parsed by the Slack action, not a shell), so it isn't the `run:`-block script-injection vector this issue describes; its values are either trusted (`github.repository`, `github.workflow`) or already-sanitized step outputs.

## Validation

No automated test exists for this workflow (it's YAML, not application code). Validated by:
- Reading the resulting YAML carefully (steps, indentation, `id:`s all correct; no leftover `${{ }}` inside the fixed step's `run:` body).
- Parsing the file with a YAML parser to confirm it's well-formed.
- A local `bash` dry run of the extracted shell logic with adversarial env values — including the exact `(#158)`-style commit message that caused the original failure, plus messages/titles with backticks, quotes, and shell metacharacters (e.g. `evil"; echo pwned; #`) — confirming no syntax errors and that injected text is treated as inert data, never executed.
- `pnpm lint` and `pnpm format:check` pass (no `src/` files touched).

**Real end-to-end validation of the Slack step only happens once this merges and the next push/PR/issue event triggers the workflow for real** — @yiddytlq, please confirm that run succeeds after merge.

Closes #160. Advances item 4.5 of #148 (Post-modernization roadmap, Milestone 4: Ops & supply chain).


---
_Generated by [Claude Code](https://claude.ai/code/session_01G82irpgaFVf29bLsQWNHJp)_