### PR TITLE
feat: warn when TIMER_TARGET datetime lacks a UTC offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you use docker, just edit the `docker-compose.yml` file so that it fits your 
 | Variables               | Definition                                                                                                             | Example                                              |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | TIMER_BACKGROUND        | The url of an image that will be used for as background                                                                | https://wallpaperplay.com/walls/full/0/7/6/29912.jpg |
-| TIMER_TARGET            | The target date of the countdown                                                                                       | Fri Oct 01 2021 15:33:36 GMT+0200                    |
+| TIMER_TARGET            | The target date of the countdown — use an explicit UTC offset (see below)                                              | Fri Oct 01 2021 15:33:36 GMT+0200                    |
 | TIMER_TITLE             | The title of the countdown, can be empty                                                                               | My title!                                            |
 | TIMER_DONE_MESSAGE      | Text shown when the countdown reaches zero (default `The wait is over!`)                                               | Happy new year!                                      |
 | TIMER_DONE_COUNTUP      | `true`/`false` (default `false`) — keep counting up past zero instead of freezing; all other TIMER_DONE_\* are ignored | true                                                 |
@@ -39,6 +39,26 @@ flags are independent and combinable (e.g. message + animation + delayed redirec
 3. If both `TIMER_DONE_RELOAD` and a valid `TIMER_DONE_REDIRECT_URL` are set, the redirect wins;
    the reload only fires when the redirect URL is unset or invalid.
 4. If neither reload nor redirect is set, the done state stays visible indefinitely.
+
+### Timezone handling for TIMER_TARGET
+
+`TIMER_TARGET` is parsed with JavaScript's `Date` constructor, which follows the ISO 8601 rule:
+
+- A **bare date** like `2026-12-31` (no time component) always parses as UTC — unambiguous
+  regardless of who's viewing it.
+- A **datetime with a time component and no UTC offset**, like `2026-12-31T20:00:00`, parses in
+  **each viewer's local timezone**. Since `TIMER_TARGET` is a single deployment-wide value, this
+  means viewers in different timezones see different remaining time for the same countdown.
+
+To get the same countdown for everyone, always include an explicit offset or `Z`:
+
+```
+TIMER_TARGET="2026-12-31T20:00:00+02:00"   # explicit offset
+TIMER_TARGET="2026-12-31T20:00:00Z"        # UTC
+```
+
+If `TIMER_TARGET` has a time component but no offset, the app logs a `console.warn` in the
+browser's developer console (not the container's stdout/stderr) recommending one.
 
 ### Example of `docker-compose.yml` file
 

--- a/public/variables.js
+++ b/public/variables.js
@@ -1,5 +1,6 @@
 window.background = '__BACKGROUND__';
 window.target = new Date('__END__');
+window.targetRaw = '__END__';
 window.title = '__TITLE__' || '';
 window.doneMessage = '__DONE_MESSAGE__' || '';
 window.doneCountup = '__DONE_COUNTUP__' === 'true';

--- a/src/scenes/Home/__tests__/Home.test.tsx
+++ b/src/scenes/Home/__tests__/Home.test.tsx
@@ -21,6 +21,7 @@ const LABEL_PATTERN = /^(days?|hours?|minutes?|seconds?)$/;
 
 interface HomeGlobals {
   target: Date;
+  targetRaw?: string;
   title?: string;
   background?: string;
   doneMessage?: string;
@@ -37,6 +38,7 @@ interface HomeGlobals {
 // Defaults mirror public/variables.js with no TIMER_* env vars set.
 async function renderHome({
   target,
+  targetRaw = '',
   title = '',
   background = 'background.jpg',
   doneMessage = '',
@@ -48,6 +50,7 @@ async function renderHome({
   doneDelayMs = 3000,
 }: HomeGlobals) {
   window.target = target;
+  window.targetRaw = targetRaw;
   window.title = title;
   window.background = background;
   window.doneMessage = doneMessage;

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState, useMemo, useRef } from 'react';
 import { describe, formatRemaining } from '../../service/date';
-import { resolveTarget } from '../../service/target';
+import { resolveTarget, warnIfAmbiguousTimezone } from '../../service/target';
 import { resolveCompletion } from '../../service/completion';
 import { redirectTo, reloadPage } from '../../service/navigation';
 import Block from './Block';
 
 const end = resolveTarget(window.target);
+warnIfAmbiguousTimezone(window.targetRaw, end);
 const completion = resolveCompletion({
   countup: window.doneCountup,
   message: window.doneMessage,

--- a/src/service/__tests__/Target.test.ts
+++ b/src/service/__tests__/Target.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { resolveTarget } from '../target';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hasAmbiguousTimezone, resolveTarget, warnIfAmbiguousTimezone } from '../target';
 
 describe('resolveTarget', () => {
   it('returns the date for a valid ISO string', () => {
@@ -17,5 +17,72 @@ describe('resolveTarget', () => {
 
   it("returns null for the raw '__END__' placeholder", () => {
     expect(resolveTarget(new Date('__END__'))).toBeNull();
+  });
+});
+
+describe('hasAmbiguousTimezone', () => {
+  it('returns true for a datetime with no UTC offset', () => {
+    expect(hasAmbiguousTimezone('2026-12-31T20:00:00')).toBe(true);
+  });
+
+  it('returns true for an offset-less datetime with fractional seconds', () => {
+    expect(hasAmbiguousTimezone('2026-12-31T20:00:00.123')).toBe(true);
+  });
+
+  it("returns false for a datetime with a trailing 'Z'", () => {
+    expect(hasAmbiguousTimezone('2026-12-31T20:00:00Z')).toBe(false);
+  });
+
+  it('returns false for a datetime with an explicit offset', () => {
+    expect(hasAmbiguousTimezone('2026-12-31T20:00:00+02:00')).toBe(false);
+  });
+
+  it('returns false for a bare date-only string', () => {
+    expect(hasAmbiguousTimezone('2026-12-31')).toBe(false);
+  });
+
+  it('returns false for a non-ISO string', () => {
+    expect(hasAmbiguousTimezone('Fri Oct 01 2021 15:33:36 GMT+0200')).toBe(false);
+  });
+});
+
+describe('warnIfAmbiguousTimezone', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns for a valid, offset-less datetime target', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw = '2026-12-31T20:00:00';
+
+    warnIfAmbiguousTimezone(raw, new Date(raw));
+
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('does not warn when the target has an explicit offset', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw = '2026-12-31T20:00:00Z';
+
+    warnIfAmbiguousTimezone(raw, new Date(raw));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for a bare date-only target', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const raw = '2026-12-31';
+
+    warnIfAmbiguousTimezone(raw, new Date(raw));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when the target failed to resolve', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    warnIfAmbiguousTimezone('2026-12-31T20:00:00', null);
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/service/target.ts
+++ b/src/service/target.ts
@@ -4,3 +4,29 @@
 export function resolveTarget(raw: Date): Date | null {
   return Number.isNaN(raw.getTime()) ? null : raw;
 }
+
+// Matches an ISO 8601 datetime with a time component and no UTC offset, e.g.
+// '2026-12-31T20:00:00'. A bare date ('2026-12-31') has no 'T' and never matches — it's
+// unambiguous, since date-only strings always parse as UTC. A string with a trailing 'Z' or
+// a '+HH:MM'/'-HH:MM' offset also never matches, since those trailing characters break the
+// '$' anchor.
+const OFFSETLESS_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/;
+
+export function hasAmbiguousTimezone(raw: string): boolean {
+  return OFFSETLESS_DATETIME.test(raw.trim());
+}
+
+// Warns once when a valid TIMER_TARGET has a time component but no UTC offset: it's parsed in
+// each viewer's local timezone, so the same deployment shows different remaining time to
+// viewers in different timezones. No-ops for a target that already failed to parse — resolved
+// is checked instead of re-testing raw for validity.
+export function warnIfAmbiguousTimezone(raw: string, resolved: Date | null): void {
+  if (resolved === null || !hasAmbiguousTimezone(raw)) {
+    return;
+  }
+  console.warn(
+    `TIMER_TARGET "${raw}" has no UTC offset, so it is parsed in each viewer's local timezone ` +
+      'and the same deployment may show different remaining time to viewers in different ' +
+      `timezones. Add an explicit offset (e.g. "${raw}+02:00") or use "Z" for UTC.`,
+  );
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@
 declare interface Window {
   background: string;
   target: Date;
+  targetRaw: string;
   title: string;
   doneMessage: string;
   doneCountup: boolean;


### PR DESCRIPTION
## Summary

Closes item 1.3 of #148 (timezone handling for `TIMER_TARGET` parsing).

`new Date('2026-12-31T20:00:00')` parses in the viewer's local timezone, while a bare date like
`2026-12-31` parses as UTC — an inconsistent mix. Since `TIMER_TARGET` is a single
deployment-wide value, this means the same deployment shows different remaining time to viewers
in different timezones when the value has a time component but no explicit UTC offset.

This is a warning/documentation change only, per the roadmap's scope — no `TIMER_TARGET_TZ` env
var, no timezone-database dependency, and no change to parsing behavior.

- `src/service/target.ts`: added `hasAmbiguousTimezone(raw: string): boolean`, a pure regex test
  for an ISO 8601 datetime with a time component and no trailing `Z`/offset (bare dates and
  datetimes with an explicit offset are unambiguous and never match), and
  `warnIfAmbiguousTimezone(raw, resolved)`, which logs a single `console.warn` when a *valid*
  target string is ambiguous. `resolveTarget()` itself is unchanged.
- `public/variables.js` / `src/vite-env.d.ts`: added `window.targetRaw` (the raw `TIMER_TARGET`
  string) alongside the existing pre-parsed `window.target: Date`, since the ambiguity check
  needs the original string — a `Date` object can't tell you whether it was constructed from an
  offset-less string. Substituted automatically by the existing `variables.sh` placeholder loop.
- `src/scenes/Home/index.tsx`: calls `warnIfAmbiguousTimezone(window.targetRaw, end)` at module
  scope, next to the existing `resolveTarget`/`resolveCompletion` calls.
- `README.md`: new "Timezone handling for TIMER_TARGET" section documenting the rule and
  recommending explicit offsets.

## Test plan

- [x] Added unit tests in `src/service/__tests__/Target.test.ts` for `hasAmbiguousTimezone`
      (offset-less datetime → warns; datetime with `Z`/explicit offset → no warn; bare date → no
      warn; non-ISO string → no warn) and `warnIfAmbiguousTimezone` (valid+ambiguous warns;
      valid+unambiguous doesn't; unresolved/`null` target doesn't), following the existing
      `vi.spyOn(console, 'warn')` pattern from `completion.test.ts`.
- [x] Updated `src/scenes/Home/__tests__/Home.test.tsx`'s `HomeGlobals`/`renderHome` helper with
      an optional `targetRaw` field (default `''`) so existing tests are unaffected.
- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test:coverage` (67 tests pass,
      coverage above the enforced floor), `pnpm build` all pass locally.
- [x] Manually verified `variables.sh`'s substitution produces the expected
      `window.targetRaw = '2026-12-31T20:00:00';` line in the built output.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyrZFgETY19nccMCeNhHmg)_