### PR TITLE
fix: fall back to gradient background when TIMER_BACKGROUND is unset or broken

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { resolveBackground } from '../service/background';
 
 interface Props {
   children: ReactNode;
@@ -26,9 +27,9 @@ class ErrorBoundary extends Component<Props, State> {
       return this.props.children;
     }
 
-    const background = window.background;
-    const hasBackground = background && background.length > 0 && background !== '__BACKGROUND__';
-    const style = hasBackground ? { backgroundImage: `url('${background}')` } : undefined;
+    const backgroundUrl = resolveBackground(window.background);
+    const style =
+      backgroundUrl !== null ? { backgroundImage: `url('${backgroundUrl}')` } : undefined;
 
     return (
       <div

--- a/src/scenes/Home/__tests__/Home.test.tsx
+++ b/src/scenes/Home/__tests__/Home.test.tsx
@@ -10,6 +10,16 @@ const navigationMock = vi.hoisted(() => ({
 }));
 vi.mock('../../../service/navigation', () => navigationMock);
 
+// preloadImage is mocked so background-load-failure can be simulated on demand;
+// resolveBackground keeps its real behavior since other tests rely on it.
+const backgroundMock = vi.hoisted(() => ({
+  preloadImage: vi.fn(),
+}));
+vi.mock('../../../service/background', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../service/background')>();
+  return { ...actual, preloadImage: backgroundMock.preloadImage };
+});
+
 const base = new Date('2030-01-01T00:00:00.000Z');
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -94,8 +104,17 @@ function tick(ms: number) {
   });
 }
 
+function rootDiv(container: HTMLElement): HTMLDivElement {
+  const root = container.querySelector('div');
+  if (root === null) {
+    throw new Error('No root div found');
+  }
+  return root;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  backgroundMock.preloadImage.mockResolvedValue(true);
   vi.useFakeTimers();
   vi.setSystemTime(base);
 });
@@ -351,5 +370,48 @@ describe('Home', () => {
     const message = screen.getByText(DEFAULT_DONE_MESSAGE);
     expect(message).toHaveAttribute('aria-live', 'polite');
     expect(message).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('applies the background image inline and omits the gradient fallback for a valid URL', async () => {
+    const { container } = await renderHome({ target: new Date(base.getTime() + DAY) });
+
+    const root = rootDiv(container);
+    expect(root.style.backgroundImage).toContain('background.jpg');
+    expect(root).not.toHaveClass('bg-gradient-to-br');
+  });
+
+  it('falls back to the gradient with no inline background style for an empty background', async () => {
+    const { container } = await renderHome({
+      target: new Date(base.getTime() + DAY),
+      background: '',
+    });
+
+    const root = rootDiv(container);
+    expect(root.style.backgroundImage).toBe('');
+    expect(root).toHaveClass('bg-gradient-to-br');
+  });
+
+  it("falls back to the gradient for the raw '__BACKGROUND__' placeholder", async () => {
+    const { container } = await renderHome({
+      target: new Date(base.getTime() + DAY),
+      background: '__BACKGROUND__',
+    });
+
+    const root = rootDiv(container);
+    expect(root.style.backgroundImage).toBe('');
+    expect(root).toHaveClass('bg-gradient-to-br');
+  });
+
+  it('falls back to the gradient when the background image fails to load', async () => {
+    backgroundMock.preloadImage.mockResolvedValue(false);
+
+    const { container } = await renderHome({ target: new Date(base.getTime() + DAY) });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const root = rootDiv(container);
+    expect(root.style.backgroundImage).toBe('');
+    expect(root).toHaveClass('bg-gradient-to-br');
   });
 });

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -3,10 +3,12 @@ import { describe, formatRemaining } from '../../service/date';
 import { resolveTarget, warnIfAmbiguousTimezone } from '../../service/target';
 import { resolveCompletion } from '../../service/completion';
 import { redirectTo, reloadPage } from '../../service/navigation';
+import { resolveBackground, preloadImage } from '../../service/background';
 import Block from './Block';
 
 const end = resolveTarget(window.target);
 warnIfAmbiguousTimezone(window.targetRaw, end);
+const backgroundUrl = resolveBackground(window.background);
 const completion = resolveCompletion({
   countup: window.doneCountup,
   message: window.doneMessage,
@@ -22,6 +24,7 @@ const headingClasses = 'mb-4 text-center text-3xl text-white sm:mb-6 sm:text-4xl
 function Home() {
   const [date, setDate] = useState(new Date());
   const [announcement, setAnnouncement] = useState('');
+  const [backgroundFailed, setBackgroundFailed] = useState(false);
   const lastAnnouncedBucketRef = useRef<number | null>(null);
 
   // In countup mode there is no done state: the timer runs forever.
@@ -43,6 +46,21 @@ function Home() {
       clearInterval(inter);
     };
   }, [done]);
+
+  useEffect(() => {
+    if (backgroundUrl === null) {
+      return;
+    }
+    let cancelled = false;
+    void preloadImage(backgroundUrl).then((ok) => {
+      if (!cancelled && !ok) {
+        setBackgroundFailed(true);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!done || completion.mode !== 'freeze' || completion.followUp === null) {
@@ -96,10 +114,14 @@ function Home() {
     }
   }, [date, described, doneState]);
 
+  const showBackground = backgroundUrl !== null && !backgroundFailed;
+
   return (
     <div
-      className="flex h-dvh items-center justify-center bg-cover bg-center bg-no-repeat"
-      style={{ backgroundImage: `url('${window.background}')` }}
+      className={`flex h-dvh items-center justify-center bg-cover bg-center bg-no-repeat ${
+        showBackground ? '' : 'bg-gradient-to-br from-slate-800 to-slate-950'
+      }`}
+      style={showBackground ? { backgroundImage: `url('${backgroundUrl}')` } : undefined}
     >
       <div className="flex flex-col items-center px-4">
         {described === null ? (

--- a/src/service/__tests__/Background.test.ts
+++ b/src/service/__tests__/Background.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { preloadImage, resolveBackground } from '../background';
+
+describe('resolveBackground', () => {
+  it('returns a valid URL string unchanged', () => {
+    expect(resolveBackground('https://example.com/bg.jpg')).toBe('https://example.com/bg.jpg');
+  });
+
+  it('returns null for an empty string', () => {
+    expect(resolveBackground('')).toBeNull();
+  });
+
+  it("returns null for the raw '__BACKGROUND__' placeholder", () => {
+    expect(resolveBackground('__BACKGROUND__')).toBeNull();
+  });
+});
+
+describe('preloadImage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves true when the image loads', async () => {
+    class FakeImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      loadedSrc = '';
+      set src(value: string) {
+        this.loadedSrc = value;
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal('Image', FakeImage);
+
+    await expect(preloadImage('https://example.com/bg.jpg')).resolves.toBe(true);
+  });
+
+  it('resolves false when the image errors', async () => {
+    class FakeImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      loadedSrc = '';
+      set src(value: string) {
+        this.loadedSrc = value;
+        this.onerror?.();
+      }
+    }
+    vi.stubGlobal('Image', FakeImage);
+
+    await expect(preloadImage('https://example.com/broken.jpg')).resolves.toBe(false);
+  });
+});

--- a/src/service/background.ts
+++ b/src/service/background.ts
@@ -1,0 +1,21 @@
+// An empty value or the raw __BACKGROUND__ placeholder (variables.sh never ran) means
+// no background is configured.
+export function resolveBackground(raw: string): string | null {
+  return raw === '' || raw === '__BACKGROUND__' ? null : raw;
+}
+
+// Wraps the browser Image API (like navigation.ts wraps window.location) so a
+// configured-but-broken URL (404, wrong domain, ...) can be detected and tested —
+// resolves true on load, false on error.
+export function preloadImage(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      resolve(true);
+    };
+    img.onerror = () => {
+      resolve(false);
+    };
+    img.src = url;
+  });
+}

--- a/tests/background.spec.ts
+++ b/tests/background.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { scenarioUrl } from './scenarios';
+
+// Built with TIMER_BACKGROUND pointing at a path that 404s on the preview server
+// (broken URL/wrong domain, as distinct from TIMER_BACKGROUND being unset).
+// preloadImage() detects the failed load and Home falls back to the gradient
+// background instead of leaving the broken image request in place (#148 item 1.5).
+test.use({ baseURL: scenarioUrl('background') });
+
+test.describe('countdown with a broken background image', () => {
+  test('falls back to the gradient background', async ({ page }) => {
+    await page.goto('/');
+
+    const root = page.locator('div.bg-cover').first();
+
+    await expect
+      .poll(() => root.evaluate((el) => el.getAttribute('class') ?? ''))
+      .toContain('bg-gradient-to-br');
+    await expect(root).not.toHaveAttribute('style', /background-image/);
+  });
+});

--- a/tests/scenarios.ts
+++ b/tests/scenarios.ts
@@ -59,6 +59,18 @@ export const scenarios: Scenario[] = [
     },
   },
   {
+    name: 'background',
+    port: 4178,
+    outDir: 'build-e2e/background',
+    env: {
+      // A path that 404s on the preview server — the broken/wrong-domain case
+      // (issue #148 item 1.5), as opposed to TIMER_BACKGROUND being unset.
+      TIMER_BACKGROUND: '/nonexistent-background.jpg',
+      TIMER_TARGET: FUTURE_TARGET,
+      TIMER_TITLE: TITLE,
+    },
+  },
+  {
     name: 'redirect',
     port: 4177,
     outDir: 'build-e2e/redirect',

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -6,6 +6,10 @@ test.describe('countdown smoke (valid target)', () => {
   test('renders configured countdown and ticks', async ({ page }) => {
     await page.goto('/');
 
+    // TIMER_BACKGROUND is unset for this build — confirms the gradient fallback
+    // (#148 item 1.5) coexists with a working countdown.
+    await expect(page.locator('div.bg-cover').first()).toHaveClass(/bg-gradient-to-br/);
+
     // The runtime-configured title (from TIMER_TITLE via variables.sh) must reach
     // both the document title and the on-screen heading.
     const configuredTitle = await page.evaluate(() => window.title);


### PR DESCRIPTION
## Summary

An unset or unsubstituted `TIMER_BACKGROUND` (empty string, or the raw `__BACKGROUND__` placeholder when `variables.sh` never ran) produced a bogus `url('')`/`url('__BACKGROUND__')` image request on every load. A configured-but-broken URL (404, wrong domain) also failed silently with no fallback. This closes item 1.5 ("Background image failure fallback") of the post-modernization roadmap in #148.

## Changes

- New `src/service/background.ts`:
  - `resolveBackground(raw: string): string | null` — treats `''` and `'__BACKGROUND__'` as "no background configured" (mirrors the existing `resolveTarget`/`resolveCompletion` resolver pattern).
  - `preloadImage(url: string): Promise<boolean>` — wraps the browser `Image` API (like `navigation.ts` wraps `window.location`) so a configured-but-broken URL can be detected and tested.
- `src/scenes/Home/index.tsx`: resolves `window.background` once at module scope, preloads it on mount, and renders a `bg-gradient-to-br from-slate-800 to-slate-950` Tailwind fallback instead of the inline `backgroundImage` style whenever there's no valid/loadable background.
- `src/components/ErrorBoundary.tsx`: reuses `resolveBackground` instead of its own duplicated empty/placeholder check, so there's a single source of truth.
- Unit tests: `src/service/__tests__/Background.test.ts` (valid URL, empty string, `'__BACKGROUND__'` placeholder, and `preloadImage` load/error paths via a stubbed global `Image`).
- Component tests: extended `src/scenes/Home/__tests__/Home.test.tsx` with cases for a valid background, an empty background, the raw placeholder, and a failed preload.
- E2E: new `background` scenario (`tests/scenarios.ts`) + `tests/background.spec.ts` covering the broken-URL case end-to-end, plus an assertion in `tests/smoke.spec.ts` that the gradient renders alongside a working countdown when no background is configured.

## Related issues

Closes item 1.5 of #148.

## Testing

- [x] Unit/component tests added or updated (`pnpm test`)
- [x] Runtime-config changes (`TIMER_*` vars, `window.*` globals, `variables.sh`, target/completion behavior) ship with a Playwright E2E scenario (`tests/scenarios.ts` + `tests/<name>.spec.ts`)
- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build` pass locally
- [x] `pnpm test:coverage` passes (97.76% stmts / 98.29% branch / 92.5% funcs / 97.7% lines — above the enforced floor)
- [x] `pnpm test:e2e` passes (7 scenarios)
- [x] Manually verified with local builds: unset `TIMER_BACKGROUND` → gradient; valid same-origin image → renders normally; broken/404 URL → gradient fallback


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAMLUxZ7utbrduqSFbNVPe)_