### PR TITLE
fix: substitute TIMER_* values literally and stop probes burying the log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ TIMER_DONE_HIDE_TIMER=
 TIMER_DONE_RELOAD=
 TIMER_DONE_REDIRECT_URL=
 TIMER_DONE_DELAY_MS=
+
+# Container log verbosity: debug | info | error (default info).
+# 'error' also turns off the nginx access log — useful on an SD card, where
+# per-request logging is real write volume.
+LOG_LEVEL=info

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,21 @@ RUN pnpm build
 # --- runtime: static files only, no node/node_modules ---
 FROM nginx:alpine-slim
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Template, not conf.d: docker-entrypoint.sh renders it per LOG_LEVEL at start,
+# so nginx never loads a copy with placeholders still in it.
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 COPY --from=build /app/build /usr/share/nginx/html
 # Pristine variables.js (placeholders intact) + injection script for container-start configuration
 COPY public/variables.js /usr/share/nginx/html/variables.js
-COPY variables.sh docker-entrypoint.sh /
+# /usr/local/bin, not /: the nginx base image ships its own /docker-entrypoint.sh,
+# and copying ours to / silently overwrote it.
+COPY variables.sh docker-entrypoint.sh /usr/local/bin/
 
 EXPOSE 3000
 
-# wget is a busybox applet already present in nginx:alpine-slim — no extra packages
-HEALTHCHECK CMD wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1
+# wget is a busybox applet already present in nginx:alpine-slim — no extra packages.
+# /healthz is the one route that is not access-logged, so probing it every 30s
+# does not bury the log in noise.
+HEALTHCHECK CMD wget -qO- http://127.0.0.1:3000/healthz >/dev/null || exit 1
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/__tests__/Variables.test.ts
+++ b/__tests__/Variables.test.ts
@@ -1,9 +1,17 @@
 // @vitest-environment node
 import { spawnSync } from 'node:child_process';
-import { copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createContext, runInContext } from 'node:vm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const root = fileURLToPath(new URL('..', import.meta.url));
@@ -17,6 +25,25 @@ function runVariables(env: Record<string, string>) {
     env: { ...process.env, TIMER_BACKGROUND: '', TIMER_TARGET: '', TIMER_TITLE: '', ...env },
     encoding: 'utf8',
   });
+}
+
+interface Injected {
+  background: string;
+  title: string;
+  doneMessage: string;
+  doneRedirectUrl: string;
+  doneDelayMs: number;
+}
+
+/**
+ * Evaluate the generated file the way the browser will. Asserting on evaluated
+ * globals rather than on the source text is deliberate: a value can look
+ * correct in the file and still be a syntax error that blanks the page.
+ */
+function evaluate(): Injected {
+  const context = createContext({ window: {} });
+  runInContext(readFileSync(join(dir, 'variables-final.js'), 'utf8'), context);
+  return (context as { window: Injected }).window;
 }
 
 beforeEach(() => {
@@ -64,5 +91,81 @@ describe.skipIf(process.platform === 'win32')('variables.sh', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('[variables.sh] ERROR: cannot copy');
     expect(existsSync(join(dir, 'variables-final.js'))).toBe(false);
+  });
+  // Each case below either killed the container at startup or silently produced
+  // a broken page under the previous sed implementation, which built
+  // `s@__X__@$VALUE@g` out of user input using @ as the delimiter.
+  describe('values containing shell or sed metacharacters', () => {
+    it.each([
+      ['TIMER_TITLE', 'Party @ midnight'],
+      ['TIMER_BACKGROUND', 'https://user@cdn.example.com/a.jpg'],
+      ['TIMER_DONE_REDIRECT_URL', 'https://user@host/next'],
+      ['TIMER_DONE_MESSAGE', 'Ping @everyone'],
+    ])('substitutes %s when the value contains @', (name, value) => {
+      copyFileSync(template, join(dir, 'variables.js'));
+
+      const result = runVariables({ [name]: value });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(join(dir, 'variables-final.js'), 'utf8')).toContain(value);
+    });
+
+    it('does not treat & as a backreference', () => {
+      copyFileSync(template, join(dir, 'variables.js'));
+
+      const result = runVariables({ TIMER_TITLE: 'Tom & Jerry' });
+
+      expect(result.status).toBe(0);
+      expect(evaluate().title).toBe('Tom & Jerry');
+    });
+  });
+
+  describe('values needing escaping in the generated javascript', () => {
+    it.each([
+      ['an apostrophe', "Chesky's wedding"],
+      ['a backslash', 'back\\slash'],
+      ['a backslash before a quote', "a\\'b"],
+    ])('emits valid javascript for %s', (_label, value) => {
+      copyFileSync(template, join(dir, 'variables.js'));
+
+      const result = runVariables({ TIMER_TITLE: value });
+
+      expect(result.status).toBe(0);
+      expect(evaluate().title).toBe(value);
+    });
+
+    it('does not let a value break out of its string literal', () => {
+      copyFileSync(template, join(dir, 'variables.js'));
+
+      const result = runVariables({ TIMER_TITLE: "'; window.pwned = true; x = '" });
+
+      expect(result.status).toBe(0);
+      const injected = evaluate();
+      expect(injected.title).toBe("'; window.pwned = true; x = '");
+      expect((injected as unknown as Record<string, unknown>).pwned).toBeUndefined();
+    });
+
+    it('leaves a value that looks like a placeholder alone', () => {
+      copyFileSync(template, join(dir, 'variables.js'));
+
+      const result = runVariables({ TIMER_BACKGROUND: '__TITLE__', TIMER_TITLE: 'real title' });
+
+      expect(result.status).toBe(0);
+      const injected = evaluate();
+      expect(injected.background).toBe('__TITLE__');
+      expect(injected.title).toBe('real title');
+    });
+  });
+
+  it('fails loudly when the template has a placeholder with no TIMER_* mapping', () => {
+    copyFileSync(template, join(dir, 'variables.js'));
+    writeFileSync(join(dir, 'variables.js'), "window.foo = '__NOT_WIRED_UP__';\n", {
+      flag: 'a',
+    });
+
+    const result = runVariables({});
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('__NOT_WIRED_UP__');
   });
 });

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,13 +1,21 @@
 services:
   web:
-    stdin_open: true # So that the serving is not exited with code 0
+    # Without this the container does not come back after a host reboot or a
+    # Docker daemon restart: the daemon only restores containers that have a
+    # restart policy.
+    restart: unless-stopped
     image: yiddy/simple-countdown
     env_file: .env
     ports:
       - '3000:3000'
     healthcheck:
-      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1']
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3000/healthz >/dev/null || exit 1']
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 5s
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 services:
   web:
+    # Without this the container does not come back after a host reboot or a
+    # Docker daemon restart: the daemon only restores containers that have a
+    # restart policy.
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile
@@ -14,11 +18,17 @@ services:
       TIMER_DONE_RELOAD: ${TIMER_DONE_RELOAD}
       TIMER_DONE_REDIRECT_URL: ${TIMER_DONE_REDIRECT_URL}
       TIMER_DONE_DELAY_MS: ${TIMER_DONE_DELAY_MS}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
     ports:
       - '3000:3000'
     healthcheck:
-      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3000/ >/dev/null || exit 1']
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3000/healthz >/dev/null || exit 1']
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 5s
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,17 +1,52 @@
 #!/bin/sh
+# Container start: inject TIMER_* env into variables-final.js, render the nginx
+# config for the requested LOG_LEVEL, verify both, then hand off to nginx.
 set -e
 
-echo "[entrypoint] simple-countdown container starting"
+# Overridable so this can be exercised outside a container; the defaults are the
+# only values ever used in the image.
+: "${HTML_DIR:=/usr/share/nginx/html}"
+: "${TEMPLATE:=/etc/nginx/templates/default.conf.template}"
+: "${CONF:=/etc/nginx/conf.d/default.conf}"
+: "${VARIABLES_SH:=/usr/local/bin/variables.sh}"
+
+# debug | info | error (default info). Anything else falls back to info.
+LOG_LEVEL_RAW="${LOG_LEVEL:-info}"
+case "$LOG_LEVEL_RAW" in
+    debug) LOG_THRESHOLD=0 ;;
+    info) LOG_THRESHOLD=1 ;;
+    error) LOG_THRESHOLD=3 ;;
+    *) LOG_THRESHOLD=1 ;;
+esac
+
+log() {
+    case "$1" in
+        debug) lvl=0 ;;
+        info) lvl=1 ;;
+        warn) lvl=2 ;;
+        *) lvl=3 ;;
+    esac
+    [ "$lvl" -ge "$LOG_THRESHOLD" ] || return 0
+    shift
+    echo "[entrypoint] $*" >&2
+}
+
+log info "simple-countdown container starting (log level ${LOG_LEVEL_RAW})"
+case "$LOG_LEVEL_RAW" in
+    debug | info | error) ;;
+    *) log warn "unknown LOG_LEVEL '${LOG_LEVEL_RAW}', using info" ;;
+esac
 
 # Inject TIMER_* env vars into variables-final.js at container start,
 # so one prebuilt image is configured per-deployment.
-if /variables.sh /usr/share/nginx/html; then
-    echo "[entrypoint] runtime configuration injected"
+if "$VARIABLES_SH" "$HTML_DIR"; then
+    log info "runtime configuration injected"
 else
     status=$?
-    echo "[entrypoint] ERROR: variables.sh failed with exit code $status" >&2
+    log error "ERROR: variables.sh failed with exit code $status"
     exit "$status"
 fi
+log debug "$(cat "$HTML_DIR/variables-final.js")"
 
 # Presence only - values may be long or sensitive
 for name in TIMER_BACKGROUND TIMER_TARGET TIMER_TITLE TIMER_DONE_MESSAGE TIMER_DONE_COUNTUP \
@@ -19,11 +54,56 @@ for name in TIMER_BACKGROUND TIMER_TARGET TIMER_TITLE TIMER_DONE_MESSAGE TIMER_D
     TIMER_DONE_DELAY_MS; do
     eval "value=\${$name:-}"
     if [ -n "$value" ]; then
-        echo "[entrypoint] $name set"
+        log info "$name set"
     else
-        echo "[entrypoint] $name not set"
+        log info "$name not set"
     fi
 done
 
-echo "[entrypoint] starting nginx"
+if [ -z "${TIMER_TARGET:-}" ]; then
+    log warn "TIMER_TARGET is not set - the page will show a configuration error"
+fi
+
+# A TIMER_* this image does not implement is otherwise ignored in silence: the
+# setting looks applied and never is.
+for var in $(env | sed -n 's/^\(TIMER_[A-Z0-9_]*\)=.*/\1/p'); do
+    case "$var" in
+        TIMER_BACKGROUND | TIMER_TARGET | TIMER_TITLE | TIMER_DONE_MESSAGE | TIMER_DONE_COUNTUP | \
+            TIMER_DONE_ANIMATION | TIMER_DONE_HIDE_TIMER | TIMER_DONE_RELOAD | \
+            TIMER_DONE_REDIRECT_URL | TIMER_DONE_DELAY_MS) ;;
+        *) log warn "ignoring $var: not implemented by this image" ;;
+    esac
+done
+
+# Quieter levels drop per-request logging entirely: that write volume is a real
+# cost on an SD card, and it is pure noise once the service is healthy.
+if [ "$LOG_LEVEL_RAW" = "error" ]; then
+    ACCESS_LOG="off"
+    ERROR_LOG_LEVEL="error"
+elif [ "$LOG_LEVEL_RAW" = "debug" ]; then
+    ACCESS_LOG="/dev/stdout main"
+    ERROR_LOG_LEVEL="info"
+else
+    ACCESS_LOG="/dev/stdout main"
+    ERROR_LOG_LEVEL="notice"
+fi
+
+sed -e "s|__ACCESS_LOG__|${ACCESS_LOG}|g" \
+    -e "s|__ERROR_LOG_LEVEL__|${ERROR_LOG_LEVEL}|g" \
+    "$TEMPLATE" >"$CONF"
+log debug "rendered $CONF (access_log ${ACCESS_LOG}, error_log ${ERROR_LOG_LEVEL})"
+
+if nginx -t 2>/dev/null; then
+    log info "nginx config test passed"
+else
+    log error "ERROR: nginx config test failed:"
+    nginx -t >&2 2>&1 || true
+    exit 1
+fi
+
+log info "starting nginx"
+
+# exec so nginx is PID 1 and receives SIGQUIT/SIGTERM directly. Wrapping it to
+# trap signals here would need hand-rolled forwarding, and nginx already logs its
+# own shutdown to error_log.
 exec nginx -g 'daemon off;'

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,10 +1,31 @@
+# Rendered to /etc/nginx/conf.d/default.conf by docker-entrypoint.sh, which
+# substitutes __ACCESS_LOG__ and __ERROR_LOG_LEVEL__ from LOG_LEVEL. It ships in
+# /etc/nginx/templates/ so nginx never loads it with placeholders still in it.
+
 server {
     listen 3000;
     root /usr/share/nginx/html;
     index index.html;
 
+    # Server-level directives override the http-level defaults inherited from the
+    # base image, rather than adding a second destination alongside them.
+    access_log __ACCESS_LOG__;
+
+    # notice by default: nginx reports startup and shutdown at this level,
+    # including "signal 3 (SIGQUIT) received, shutting down". That line is what
+    # distinguishes an orderly stop from a crash, so it outlives quieter levels.
+    error_log /dev/stderr __ERROR_LOG_LEVEL__;
+
     location / {
         try_files $uri /index.html;
+    }
+
+    # Probed by HEALTHCHECK every 30s and typically by an external monitor too.
+    # Never access-logged: at that rate it buries everything worth reading.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
     }
 
     # Vite content-hashed bundles: safe to cache forever

--- a/package.json
+++ b/package.json
@@ -54,5 +54,13 @@
     "typescript-eslint": "^8.64.0",
     "vite": "^8.1.5",
     "vitest": "^4.1.10"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion@<1.1.18": "^1.1.18",
+      "brace-expansion@>=4.0.0 <5.0.8": "^5.0.9",
+      "js-yaml@>=4.0.0 <4.3.1": "^4.3.1",
+      "undici@>=7.0.0 <7.29.0": "^7.29.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=4.0.0 <5.0.8: ^5.0.9
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
+  undici@>=7.0.0 <7.29.0: ^7.29.0
+
 importers:
 
   .:
@@ -967,12 +973,12 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1856,8 +1862,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -2926,8 +2932,8 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -3393,7 +3399,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3641,7 +3647,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.7(typescript@6.0.3)
       tinyglobby: 0.2.17
-      undici: 7.28.0
+      undici: 7.29.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - kerberos
@@ -4119,12 +4125,12 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4266,7 +4272,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -5136,7 +5142,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -5157,7 +5163,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5363,11 +5369,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -6197,7 +6203,7 @@ snapshots:
 
   undici@6.27.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/tests/metacharacters.spec.ts
+++ b/tests/metacharacters.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { readBlocks } from './helpers';
+import { scenarioUrl } from './scenarios';
+
+const TITLE = "Chesky & Ruchy's wedding @ 6pm";
+
+// Unit tests cover variables.sh directly; this is the only layer that proves a
+// value carrying sed and JS metacharacters survives a real `vite build` and
+// parses in a browser. Under the previous sed implementation this build either
+// failed outright (@) or shipped a variables-final.js with a syntax error (').
+test.use({ baseURL: scenarioUrl('metacharacters') });
+
+test.describe('TIMER_* values containing metacharacters', () => {
+  test('reach the page intact and leave the countdown working', async ({ page }) => {
+    await page.goto('/');
+
+    // A syntax error in variables-final.js leaves window.* undefined, so this
+    // assertion also covers "the generated file parsed at all".
+    expect(await page.evaluate(() => window.title)).toBe(TITLE);
+    expect(await page.evaluate(() => window.doneMessage)).toBe("It's done @ last!");
+    expect(await page.evaluate(() => window.doneRedirectUrl)).toBe('http://user@localhost:4173/');
+
+    await expect(page).toHaveTitle(TITLE);
+    await expect(page.getByText(TITLE, { exact: true })).toBeVisible();
+
+    // No placeholder may survive substitution.
+    expect(await page.evaluate(() => document.body.innerHTML)).not.toMatch(/__[A-Z_]+__/);
+
+    // The countdown still renders: the target was substituted correctly too.
+    await expect
+      .poll(async () => (await readBlocks(page)).every((block) => block.valid))
+      .toBe(true);
+    expect(await readBlocks(page)).toHaveLength(4);
+  });
+});

--- a/tests/scenarios.ts
+++ b/tests/scenarios.ts
@@ -71,6 +71,23 @@ export const scenarios: Scenario[] = [
     },
   },
   {
+    // Every character that broke the old sed-based substitution, in one build:
+    // @ was the sed delimiter (exited non-zero, so the container never started),
+    // & was a backreference, and an apostrophe closed the JS string literal and
+    // blanked the page. Only a real build proves the value survives variables.sh
+    // and reaches the browser intact.
+    name: 'metacharacters',
+    port: 4179,
+    outDir: 'build-e2e/metacharacters',
+    env: {
+      TIMER_BACKGROUND: '',
+      TIMER_TARGET: FUTURE_TARGET,
+      TIMER_TITLE: "Chesky & Ruchy's wedding @ 6pm",
+      TIMER_DONE_MESSAGE: "It's done @ last!",
+      TIMER_DONE_REDIRECT_URL: 'http://user@localhost:4173/',
+    },
+  },
+  {
     name: 'redirect',
     port: 4177,
     outDir: 'build-e2e/redirect',

--- a/variables.sh
+++ b/variables.sh
@@ -1,23 +1,119 @@
 #!/bin/sh
+# Substitute TIMER_* env vars into <dir>/variables.js -> <dir>/variables-final.js.
+#
+# Runs before vite (pnpm dev / pnpm build) and again at container start, so one
+# prebuilt image is configured per deployment. See CLAUDE.md.
+#
+# awk reads each value straight from ENVIRON and substitutes it literally. No
+# value is ever interpolated into a regex, a sed expression or a shell word, so
+# an @, &, backslash or quote in a TIMER_* value cannot corrupt the output or
+# stop the container from starting.
+set -eu
 
-dir=$1
+dir=${1:?usage: variables.sh <dir>}
 
-cp "$dir/variables.js" "$dir/variables-final.js" || {
+if [ ! -r "$dir/variables.js" ]; then
     echo "[variables.sh] ERROR: cannot copy $dir/variables.js to $dir/variables-final.js" >&2
     exit 1
+fi
+
+awk '
+# Escape for a JS single-quoted string literal. The characters are built with
+# sprintf so this program needs no backslash escapes of its own -- and so that
+# it can handle a single quote at all, being itself inside one.
+function js_escape(s) {
+    s = replace(s, BS, BS BS)   # backslashes first, or we double our own output
+    s = replace(s, SQ, BS SQ)
+    s = replace(s, CR, "")
+    s = replace(s, LF, " ")
+    return s
 }
 
-for pair in "__BACKGROUND__=$TIMER_BACKGROUND" "__END__=$TIMER_TARGET" "__TITLE__=$TIMER_TITLE" \
-    "__DONE_MESSAGE__=$TIMER_DONE_MESSAGE" "__DONE_COUNTUP__=$TIMER_DONE_COUNTUP" \
-    "__DONE_ANIMATION__=$TIMER_DONE_ANIMATION" "__DONE_HIDE_TIMER__=$TIMER_DONE_HIDE_TIMER" \
-    "__DONE_RELOAD__=$TIMER_DONE_RELOAD" "__DONE_REDIRECT_URL__=$TIMER_DONE_REDIRECT_URL" \
-    "__DONE_DELAY_MS__=$TIMER_DONE_DELAY_MS"; do
-    placeholder=${pair%%=*}
-    value=${pair#*=}
-    sed -i -e "s@$placeholder@$value@g" "$dir/variables-final.js" || {
-        echo "[variables.sh] ERROR: substitution of $placeholder failed" >&2
-        exit 1
+# Literal replacement using index()/substr() only: the needle is never a regex
+# and & is never a backreference.
+function replace(hay, needle, rep,    acc, p) {
+    acc = ""
+    while ((p = index(hay, needle)) > 0) {
+        acc = acc substr(hay, 1, p - 1) rep
+        hay = substr(hay, p + length(needle))
     }
-done
+    return acc hay
+}
+
+function add(placeholder, envvar) {
+    NP++
+    PH[NP] = placeholder
+    VAL[placeholder] = js_escape(ENVIRON[envvar])
+}
+
+# Single left-to-right pass: always take the earliest (then longest) placeholder
+# and continue past the text just inserted. Substituting one placeholder at a
+# time across the whole line would let a value that happens to contain another
+# placeholder be rewritten by a later round.
+function substitute(line,    out, best, bestpos, i, p) {
+    out = ""
+    while (1) {
+        bestpos = 0
+        best = ""
+        for (i = 1; i <= NP; i++) {
+            p = index(line, PH[i])
+            if (p > 0 && (bestpos == 0 || p < bestpos ||
+                          (p == bestpos && length(PH[i]) > length(best)))) {
+                bestpos = p
+                best = PH[i]
+            }
+        }
+        if (bestpos == 0) break
+        out = out substr(line, 1, bestpos - 1) VAL[best]
+        line = substr(line, bestpos + length(best))
+    }
+    return out line
+}
+
+BEGIN {
+    BS = sprintf("%c", 92)
+    SQ = sprintf("%c", 39)
+    CR = sprintf("%c", 13)
+    LF = sprintf("%c", 10)
+
+    NP = 0
+    add("__BACKGROUND__", "TIMER_BACKGROUND")
+    add("__END__", "TIMER_TARGET")
+    add("__TITLE__", "TIMER_TITLE")
+    add("__DONE_MESSAGE__", "TIMER_DONE_MESSAGE")
+    add("__DONE_COUNTUP__", "TIMER_DONE_COUNTUP")
+    add("__DONE_ANIMATION__", "TIMER_DONE_ANIMATION")
+    add("__DONE_HIDE_TIMER__", "TIMER_DONE_HIDE_TIMER")
+    add("__DONE_RELOAD__", "TIMER_DONE_RELOAD")
+    add("__DONE_REDIRECT_URL__", "TIMER_DONE_REDIRECT_URL")
+    add("__DONE_DELAY_MS__", "TIMER_DONE_DELAY_MS")
+}
+
+# Catches a placeholder added to variables.js that nobody wired up here. Scans
+# the template, never the output, so a TIMER_* value that happens to contain
+# __SOMETHING__ is not mistaken for a failed substitution.
+function check_unknown(line,    rest, tok) {
+    rest = line
+    while (match(rest, /__[A-Z0-9_]+__/)) {
+        tok = substr(rest, RSTART, RLENGTH)
+        if (!(tok in VAL)) UNKNOWN[tok] = 1
+        rest = substr(rest, RSTART + RLENGTH)
+    }
+}
+
+{
+    check_unknown($0)
+    print substitute($0)
+}
+
+END {
+    bad = 0
+    for (tok in UNKNOWN) {
+        print "[variables.sh] ERROR: template placeholder " tok " has no TIMER_* mapping" > "/dev/stderr"
+        bad = 1
+    }
+    if (bad) exit 1
+}
+' "$dir/variables.js" >"$dir/variables-final.js"
 
 echo "[variables.sh] substituted TIMER_* placeholders into $dir/variables-final.js"


### PR DESCRIPTION
## Why

Two problems, both surfaced while diagnosing a week-long outage of a deployed container.

### 1. `variables.sh` can be killed by an `@` in any TIMER_* value

`master` builds a sed expression out of user input using `@` as the delimiter, across all ten
variables, each wrapped in `|| exit 1`:

```sh
sed -i -e "s@$placeholder@$value@g" "$dir/variables-final.js" || { ...; exit 1; }
```

Reproduced against `master`:

| Value | Result |
|---|---|
| `TIMER_TITLE='Party @ midnight'` | sed error → exit 1 → **container never starts** |
| `TIMER_DONE_REDIRECT_URL='https://user@host/x'` | same — and this one is a URL field |
| `TIMER_TITLE='Tom & Jerry'` | `&` is a sed backreference → `Tom __TITLE__ Jerry` |
| `TIMER_TITLE="Chesky's wedding"` | unescaped quote → SyntaxError → **blank white page** |

The `|| exit 1` wrappers make the `@` case a *reliable* startup crash. The apostrophe case is worse
in a way: a blank page is indistinguishable from a dead container.

### 2. The logs bury the one line that matters

A container went to `exited` and stayed down for a week. It never crashed — nginx logged
`signal 3 (SIGQUIT) received, shutting down` with exit 0, because a host reboot stopped ~30
containers at `04:50:04` and restored them at `05:00:52`. That container was the only one with
`policy=no`, so it alone never came back.

That log line was present the whole time, under **~750 access-log lines an hour** of monitoring
probes — because the healthcheck added in #152 hits `/`, which is access-logged.

## What changed

**Substitution** — now runs through `awk` reading `ENVIRON`, so no value is ever interpolated into a
regex, a sed expression, or a shell word. A single left-to-right pass means a value that itself
contains `__TITLE__` isn't rewritten by a later placeholder's round. An `END` guard fails the script
when `variables.js` gains a placeholder with no `TIMER_*` mapping — it scans the *template*, never
the output, so a value containing `__SOMETHING__` is not a false positive. Existing stdout/stderr
strings are preserved.

**Logging** — `HEALTHCHECK` now hits a dedicated `/healthz` with `access_log off`. `error_log` stays
at `notice` so shutdown notices always survive. `LOG_LEVEL` (`debug|info|error`, default `info`)
tunes verbosity; `error` also disables the access log entirely, which is real write volume on an SD
card. The entrypoint additionally warns about `TIMER_*` variables the image doesn't implement — a
setting that silently does nothing is its own kind of useless log.

**Deployment defaults** — `restart: unless-stopped` and bounded `json-file` logging on both shipped
compose files, so other deployments can't reproduce that outage or grow an unbounded log. Dev
compose deliberately gets no restart policy.

**Dockerfile** — the entrypoint moves to `/usr/local/bin/`, where it no longer overwrites the nginx
base image's own `/docker-entrypoint.sh`. `nginx.conf` becomes a template rendered per `LOG_LEVEL`.

## Tests

`__tests__/Variables.test.ts` gains the metacharacter cases it lacked: `@` across four variables,
`&`, apostrophe, backslash, backslash-before-quote, a breakout attempt, a placeholder-shaped value,
and the unmapped-template guard. These evaluate the generated file in a `vm` context rather than
string-matching it — a value can look correct in the source and still be a syntax error.

**11 of the 14 fail against `master`'s `variables.sh`; all 14 pass here.**

Per CLAUDE.md, the runtime-config change ships with an E2E scenario: `metacharacters` (port 4179)
builds with `TIMER_TITLE="Chesky & Ruchy's wedding @ 6pm"` and an `@` in the redirect URL. Only E2E
proves the value survives a real `vite build` and parses in a browser — on `master` that build
aborts outright.

## Verification

`pnpm lint`, `format:check`, `typecheck`, `test:coverage` (97.85% statements, above the floor), and
`build` all pass. Full Playwright suite passes, 8/8 including the new scenario.

The entrypoint was exercised against a stubbed nginx across each log level, a bogus `LOG_LEVEL`,
empty `TIMER_TARGET`, a failing `nginx -t`, and the placeholder guard.

Verified against a real container build (`nginx:alpine-slim`, 21MB):

```
GET /                               -> 200
GET /healthz                        -> ok (200)
variables-final.js                  -> title survives the & @ and apostrophe intact
healthz lines in access log         -> 0
GET / lines in access log           -> 2     (access log is on; only /healthz is suppressed)
nginx's own /docker-entrypoint.sh   -> intact, 1620 bytes, base-image dated
ours at /usr/local/bin/             -> alongside it, no collision
```

The 0-vs-2 split is the point: probe traffic no longer reaches the access log, while ordinary
requests still do.

## Second commit: dependency pins

`pnpm audit --audit-level high` was already failing on `master` — its last CI run was 2026-07-20 and
these advisories were published in the 18 days since. Since it blocks this PR, the fix is folded in
as a separate commit: `pnpm.overrides` pinning `brace-expansion`, `js-yaml` and `undici`. All three
are transitive and tooling-only; none reach the shipped bundle.

Pinned rather than bumping direct dependencies because eslint 9.39.5 is already the newest 9.x, so
clearing the first two that way would mean eslint 10 — a major upgrade of a CI gate, out of
proportion to two patch-level advisories. The selectors are range-scoped so they lapse on their own
once the dependency trees move past them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDPgE8vu9L6KzmNp9QiuFC


