### PR TITLE
chore(ci): drop the Docker Hub description sync

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,11 +43,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-          repository: yiddy/simple-countdown
-          short-description: 'Self-hostable countdown timer. nginx-based (~21MB), configured via TIMER_* env vars at runtime.'
-          readme-filepath: ./README.md
+      # The Docker Hub description sync (peter-evans/dockerhub-description) was
+      # removed after it failed 403 on its first run in v1.6.2. That API needs a
+      # token with read/write/delete scope; DOCKER_TOKEN is read/write, which is
+      # all the push needs. Granting delete to CI — letting it drop tags and
+      # repositories — is not worth keeping a description string in sync, so the
+      # Docker Hub description is now edited by hand in the Docker Hub UI.


### PR DESCRIPTION
## Why

The "Update Docker Hub description" step failed `403 Forbidden` on the v1.6.2 release.

It was added in #165, which merged *after* v1.6.1 and is a `chore:` — so no release triggered it
until now. **It has never once succeeded.**

## The cause is scope, not a bad secret

`peter-evans/dockerhub-description` documents its `password` input as requiring a Docker Hub
password or a PAT with **`read/write/delete`** scope. `DOCKER_TOKEN` is **Read & Write**.

That matches the evidence exactly: on the same token, `Log in to Docker Hub` and
`Build and push Docker image` both succeeded, and only the description call was rejected. The
token's "last used" timestamp lines up with the push.

## Why remove rather than escalate the token

`read/write/delete` would let CI delete tags and repositories. That is a meaningful capability to
hand a workflow so that a description string stays in sync — the description has no bearing on the
image or on any deployment.

The build and push are unaffected: `1.6.2` and `latest` published fine (multi-arch, amd64 + arm64)
before this step ran. The only consequence of this failing step was marking the whole release run
red.

## Follow-up

The Docker Hub description is now maintained by hand. It is currently **empty** — `description` and
`full_description` both return `''` from the Hub API — because the sync never worked. Setting it is
a one-time manual step in the Docker Hub UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDPgE8vu9L6KzmNp9QiuFC
